### PR TITLE
Update textIndexer.bat

### DIFF
--- a/bin/textIndexer.bat
+++ b/bin/textIndexer.bat
@@ -2,6 +2,8 @@
 
 :: set the home directory
 @echo off
+set _=%cd%
+cd %~dp0
 pushd ..
 set XTF_HOME=%cd%
 popd
@@ -15,4 +17,5 @@ for %%i in ("%XTF_HOME%"\WEB-INF\lib\*.jar) do set XTFCP=!XTFCP!;%%i
 java -cp "%XTFCP%" -Xms150m -Xmx1500m -Dxtf.home="%XTF_HOME%" -DentityExpansionLimit=256000 -enableassertions org.cdlib.xtf.textIndexer.TextIndexer %*
 set XTFCP=
 set XTF_HOME=
+cd %_%
 exit

--- a/bin/textIndexer.bat
+++ b/bin/textIndexer.bat
@@ -1,8 +1,10 @@
 :: Batch file to run the XTF textIndexer on Windows
 
-:: First, let's check to make sure XTF_HOME is set properly
+:: set the home directory
 @echo off
-if not exist "%XTF_HOME%" goto NEED_HOME
+pushd ..
+set XTF_HOME=%cd%
+popd
 
 :: Make a classpath containing all the jars in XTF_HOME\WEB-INF\lib
 setlocal enabledelayedexpansion
@@ -10,17 +12,7 @@ set XTFCP=%CLASSPATH%;%XTF_HOME%\WEB-INF\classes
 for %%i in ("%XTF_HOME%"\WEB-INF\lib\*.jar) do set XTFCP=!XTFCP!;%%i
 
 :: And fire off the command.
-java -cp "%XTFCP%" -Xms50m -Xmx1000m -Dxtf.home="%XTF_HOME%" -DentityExpansionLimit=128000 -enableassertions org.cdlib.xtf.textIndexer.TextIndexer %*
+java -cp "%XTFCP%" -Xms150m -Xmx1500m -Dxtf.home="%XTF_HOME%" -DentityExpansionLimit=256000 -enableassertions org.cdlib.xtf.textIndexer.TextIndexer %*
 set XTFCP=
-exit /B 0
-                                          
-:: Print error message and exit
-:NEED_HOME
-echo ERROR: XTF_HOME environment variable not set properly.
-echo You can set it in the "System" Control Panel; look on the Advanced tab,
-echo under "Environment Variables".
-echo Note that the value should not include quotes.
-exit /B 1
-
-
-                                
+set XTF_HOME=
+exit

--- a/bin/textIndexer.bat
+++ b/bin/textIndexer.bat
@@ -2,11 +2,7 @@
 
 :: set the home directory
 @echo off
-set _=%cd%
-cd %~dp0
-pushd ..
-set XTF_HOME=%cd%
-popd
+set XTF_HOME=../%~dp0
 
 :: Make a classpath containing all the jars in XTF_HOME\WEB-INF\lib
 setlocal enabledelayedexpansion
@@ -17,5 +13,4 @@ for %%i in ("%XTF_HOME%"\WEB-INF\lib\*.jar) do set XTFCP=!XTFCP!;%%i
 java -cp "%XTFCP%" -Xms150m -Xmx1500m -Dxtf.home="%XTF_HOME%" -DentityExpansionLimit=256000 -enableassertions org.cdlib.xtf.textIndexer.TextIndexer %*
 set XTFCP=
 set XTF_HOME=
-cd %_%
 exit


### PR DESCRIPTION
Simple XTF_HOME refactor to allow for multiple instances on the same machine. It is no longer necessary to set XTF_OME as a windows Environmental Variable.