### PR TITLE
bug fixes

### DIFF
--- a/style/dynaXML/docFormatter/tei/component.xsl
+++ b/style/dynaXML/docFormatter/tei/component.xsl
@@ -594,7 +594,14 @@
    <!-- ====================================================================== -->
    <!-- References                                                             -->
    <!-- ====================================================================== -->
-   
+   <!-- links to absolute HTTP(s) URIs -->
+   <xsl:template match="*:ref[matches(@target, '^https?://')]">
+      <xsl:element name="a">
+         <xsl:attribute name="href" select="@target"/>
+         <xsl:apply-templates/>
+      </xsl:element>
+   </xsl:template>
+ 
    <xsl:template match="*:ref">
       
       <!-- variables -->

--- a/style/textIndexer/tei/teiPreFilter.xsl
+++ b/style/textIndexer/tei/teiPreFilter.xsl
@@ -248,7 +248,7 @@
             </publisher>
          </xsl:when>
          <xsl:when test="//*:text/*:front/*:titlePage//*:publisher">
-            <publisher xtf-meta="true">
+            <publisher xtf:meta="true">
                <xsl:value-of select="string(//*:text/*:front/*:titlePage//*:publisher[1])"/>
             </publisher>
          </xsl:when>
@@ -264,7 +264,7 @@
    <xsl:template name="get-tei-contributor">
       <xsl:choose>
          <xsl:when test="//*:fileDesc/*:respStmt/*:name">
-            <contributor xtf-meta="true">
+            <contributor xtf:meta="true">
                <xsl:value-of select="string(//*:fileDesc/*:respStmt/*:name[1])"/>
             </contributor>
          </xsl:when>
@@ -327,7 +327,7 @@
    <xsl:template name="get-tei-source">
       <xsl:choose>
          <xsl:when test="//*:sourceDesc/*:bibl">
-            <source xtf-meta="true">
+            <source xtf:meta="true">
                <xsl:value-of select="string(//*:sourceDesc/*:bibl[1])"/>
             </source>
          </xsl:when>
@@ -343,7 +343,7 @@
    <xsl:template name="get-tei-language">
       <xsl:choose>
          <xsl:when test="//*:profileDesc/*:langUsage/*:language">
-            <language xtf-meta="true">
+            <language xtf:meta="true">
                <xsl:value-of select="string((//*:profileDesc/*:langUsage/*:language)[1])"/>
             </language>
          </xsl:when>
@@ -359,7 +359,7 @@
    <xsl:template name="get-tei-relation">
       <xsl:choose>
          <xsl:when test="//*:fileDesc/*:seriesStmt/*:title">
-            <relation xtf-meta="true">
+            <relation xtf:meta="true">
                <xsl:value-of select="string(//*:fileDesc/*:seriesStmt/*:title)"/>
             </relation>
          </xsl:when>
@@ -380,7 +380,7 @@
    
    <!-- rights -->
    <xsl:template name="get-tei-rights">
-      <rights xtf-meta="true">
+      <rights xtf:meta="true">
          <xsl:value-of select="'public'"/>
       </rights>
    </xsl:template>


### PR DESCRIPTION
The first bug (#12) is in the TEI indexer: the `xtf:meta` attribute was incorrectly encoded with the name `xtf-meta` which the indexer would ignore. The fix supplies the correct namespaced attribute instead.

The second bug is in the stylesheet which handles TEI references, which mangles external references because it assumes that all references are internal to the document; in the fix, any reference to an external resource (with a URI beginning with `http:` or `https:`) is simply converted to an HTML hyperlink.