### PR TITLE
Local style

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ regress/**/*.log
 *.swp
 *.orig
 .ruby-version
+*.*~
+

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ regress/**/*.log
 *.swp
 *.orig
 .ruby-version
+*.*~

--- a/WEB-INF/build.xml
+++ b/WEB-INF/build.xml
@@ -127,6 +127,7 @@
         <exclude name="**/.*/**/*"/>
         <exclude name="**/CVS/**/*"/>
         <exclude name="style/crossQuery/complexQueryParser.xsl"/>
+        <exclude name="local/style/crossQuery/complexQueryParser.xsl"/>
 
         <include name="bin/classpath.pl"/>
         <include name="bin/textIndexer"/>
@@ -149,7 +150,8 @@
         <include name="script/**/*"/>
 
         <include name="style/**/*"/>
-
+        <include name="local/style/**/*"/>
+        
         <include name="INSTALL"/>
 
         <include name="LICENSE"/>
@@ -202,6 +204,7 @@
         <include name="profiles/**/*"/>
         <include name="script/**/*"/>
         <include name="style/**/*"/>
+        <include name="local/style/**/*"/>
       </fileset>
     </zip>
 

--- a/conf/crossQuery.conf
+++ b/conf/crossQuery.conf
@@ -32,7 +32,8 @@
                   directory.
     -->
 
-    <queryRouter path="style/crossQuery/queryRouter.xsl"/>
+    <queryRouter path="local/style/crossQuery/queryRouter.xsl"/>
+<!--    <queryRouter path="style/crossQuery/queryRouter.xsl"/>-->
 
 
     <!-- =====================================================================
@@ -48,7 +49,7 @@
                   See detailed comments in errorGen.xsl for more info.
     -->
 
-    <errorGen path="style/crossQuery/errorGen.xsl"/>
+    <errorGen path="local/style/crossQuery/errorGen.xsl"/>
 
 
     <!-- =====================================================================

--- a/conf/dynaXML.conf
+++ b/conf/dynaXML.conf
@@ -49,7 +49,7 @@
                   See descriptive comments in docReqParser.xsl for details.
     -->
 
-    <docReqParser path="style/dynaXML/docReqParser.xsl"/>
+    <docReqParser path="local/style/dynaXML/docReqParser.xsl"/>
 
 
     <!-- =====================================================================
@@ -65,7 +65,7 @@
                   See detailed comments in errorGen.xsl for more info.
     -->
 
-    <errorGen path="style/dynaXML/errorGen.xsl"/>
+    <errorGen path="local/style/dynaXML/errorGen.xsl"/>
 
 
     <!-- =====================================================================

--- a/conf/sru.conf
+++ b/conf/sru.conf
@@ -35,7 +35,7 @@
                   See descriptive comments in queryParser.xsl for details.
     -->
 
-    <queryParser path="style/sru/queryParser.xsl"/>
+    <queryParser path="local/style/sru/queryParser.xsl"/>
 
 
     <!-- =====================================================================
@@ -51,7 +51,7 @@
                   See detailed comments in errorGen.xsl for more info.
     -->
 
-    <errorGen path="style/sru/errorGen.xsl"/>
+    <errorGen path="local/style/sru/errorGen.xsl"/>
 
 
     <!-- =====================================================================

--- a/local/style/crossQuery/errorGen.xsl
+++ b/local/style/crossQuery/errorGen.xsl
@@ -1,0 +1,14 @@
+<!--Local customization file for "errorGen.xsl"-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">
+   <xsl:import href="../../../style/crossQuery/errorGen.xsl"/>
+
+   <!--Any declarations in this file take precedence over those in the stylesheet imported above.-->
+   <xsl:output method="xhtml"
+               indent="no"
+               encoding="UTF-8"
+               media-type="text/html; charset=UTF-8"
+               doctype-public="-//W3C//DTD XHTML 1.0 Transitional//EN"
+               doctype-system="http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"
+               omit-xml-declaration="yes"/>
+</xsl:stylesheet>
+

--- a/local/style/crossQuery/oaiErrorGen.xsl
+++ b/local/style/crossQuery/oaiErrorGen.xsl
@@ -1,0 +1,14 @@
+<!--Local customization file for "oaiErrorGen.xsl"-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:FileUtils="java:org.cdlib.xtf.xslt.FileUtils"
+                extension-element-prefixes="FileUtils"
+                version="2.0">
+   <xsl:import href="../../../style/crossQuery/oaiErrorGen.xsl"/>
+
+   <!--Any declarations in this file take precedence over those in the stylesheet imported above.-->
+   <xsl:output method="xml"
+               media-type="text/xml"
+               encoding="UTF-8"
+               indent="yes"/>
+</xsl:stylesheet>
+

--- a/local/style/crossQuery/queryParser/common/queryParserCommon.xsl
+++ b/local/style/crossQuery/queryParser/common/queryParserCommon.xsl
@@ -1,0 +1,11 @@
+<!--Local customization file for "queryParserCommon.xsl"-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:session="java:org.cdlib.xtf.xslt.Session"
+                extension-element-prefixes="session"
+                exclude-result-prefixes="#all"
+                version="2.0">
+   <xsl:import href="../../../../../style/crossQuery/queryParser/common/queryParserCommon.xsl"/>
+
+   <!--Any declarations in this file take precedence over those in the stylesheet imported above.-->
+</xsl:stylesheet>
+

--- a/local/style/crossQuery/queryParser/default/queryParser.xsl
+++ b/local/style/crossQuery/queryParser/default/queryParser.xsl
@@ -1,0 +1,15 @@
+<!--Local customization file for "queryParser.xsl"-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:session="java:org.cdlib.xtf.xslt.Session"
+                xmlns:freeformQuery="java:org.cdlib.xtf.xslt.FreeformQuery"
+                extension-element-prefixes="session freeformQuery"
+                exclude-result-prefixes="#all"
+                version="2.0">
+   <xsl:import href="../../../../../style/crossQuery/queryParser/default/queryParser.xsl"/>
+
+   <!--Any declarations in this file take precedence over those in the stylesheet imported above.-->
+   <xsl:import href="../common/queryParserCommon.xsl"/>
+   <xsl:output method="xml" indent="yes" encoding="utf-8"/>
+   <xsl:strip-space elements="*"/>
+</xsl:stylesheet>
+

--- a/local/style/crossQuery/queryParser/oai/queryParser.xsl
+++ b/local/style/crossQuery/queryParser/oai/queryParser.xsl
@@ -1,0 +1,9 @@
+<!--Local customization file for "queryParser.xsl"-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">
+   <xsl:import href="../../../../../style/crossQuery/queryParser/oai/queryParser.xsl"/>
+
+   <!--Any declarations in this file take precedence over those in the stylesheet imported above.-->
+   <xsl:output method="xml" encoding="UTF-8" indent="yes"/>
+   <xsl:strip-space elements="*"/>
+</xsl:stylesheet>
+

--- a/local/style/crossQuery/queryParser/siteMap/queryParser.xsl
+++ b/local/style/crossQuery/queryParser/siteMap/queryParser.xsl
@@ -1,0 +1,8 @@
+<!--Local customization file for "queryParser.xsl"-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">
+   <xsl:import href="../../../../../style/crossQuery/queryParser/siteMap/queryParser.xsl"/>
+
+   <!--Any declarations in this file take precedence over those in the stylesheet imported above.-->
+   <xsl:output method="xml" encoding="UTF-8" indent="yes"/>
+</xsl:stylesheet>
+

--- a/local/style/crossQuery/queryRouter.xsl
+++ b/local/style/crossQuery/queryRouter.xsl
@@ -1,0 +1,11 @@
+<!--Local customization file for "queryRouter.xsl"-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                exclude-result-prefixes="#all"
+                version="2.0">
+   <xsl:import href="../../../style/crossQuery/queryRouter.xsl"/>
+
+   <!--Any declarations in this file take precedence over those in the stylesheet imported above.-->
+   <xsl:output method="xml" indent="yes" encoding="utf-8"/>
+   <xsl:strip-space elements="*"/>
+</xsl:stylesheet>
+

--- a/local/style/crossQuery/resultFormatter/common/format-query.xsl
+++ b/local/style/crossQuery/resultFormatter/common/format-query.xsl
@@ -1,0 +1,12 @@
+<!--Local customization file for "format-query.xsl"-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:xtf="http://cdlib.org/xtf"
+                xmlns:editURL="http://cdlib.org/xtf/editURL"
+                xmlns="http://www.w3.org/1999/xhtml"
+                exclude-result-prefixes="#all"
+                version="2.0">
+   <xsl:import href="../../../../../style/crossQuery/resultFormatter/common/format-query.xsl"/>
+
+   <!--Any declarations in this file take precedence over those in the stylesheet imported above.-->
+</xsl:stylesheet>
+

--- a/local/style/crossQuery/resultFormatter/common/resultFormatterCommon.xsl
+++ b/local/style/crossQuery/resultFormatter/common/resultFormatterCommon.xsl
@@ -1,0 +1,16 @@
+<!--Local customization file for "resultFormatterCommon.xsl"-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                xmlns:xtf="http://cdlib.org/xtf"
+                xmlns:editURL="http://cdlib.org/xtf/editURL"
+                xmlns="http://www.w3.org/1999/xhtml"
+                exclude-result-prefixes="#all"
+                version="2.0">
+   <xsl:import href="../../../../../style/crossQuery/resultFormatter/common/resultFormatterCommon.xsl"/>
+
+   <!--Any declarations in this file take precedence over those in the stylesheet imported above.-->
+   <xsl:import href="../../../xtfCommon/xtfCommon.xsl"/>
+   <xsl:import href="format-query.xsl"/>
+   <xsl:import href="spelling.xsl"/>
+</xsl:stylesheet>
+

--- a/local/style/crossQuery/resultFormatter/common/spelling.xsl
+++ b/local/style/crossQuery/resultFormatter/common/spelling.xsl
@@ -1,0 +1,11 @@
+<!--Local customization file for "spelling.xsl"-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:cdl="http://cdlib.org"
+                xmlns="http://www.w3.org/1999/xhtml"
+                exclude-result-prefixes="#all"
+                version="2.0">
+   <xsl:import href="../../../../../style/crossQuery/resultFormatter/common/spelling.xsl"/>
+
+   <!--Any declarations in this file take precedence over those in the stylesheet imported above.-->
+</xsl:stylesheet>
+

--- a/local/style/crossQuery/resultFormatter/default/resultFormatter.xsl
+++ b/local/style/crossQuery/resultFormatter/default/resultFormatter.xsl
@@ -1,0 +1,24 @@
+<!--Local customization file for "resultFormatter.xsl"-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:session="java:org.cdlib.xtf.xslt.Session"
+                xmlns:editURL="http://cdlib.org/xtf/editURL"
+                xmlns="http://www.w3.org/1999/xhtml"
+                extension-element-prefixes="session"
+                exclude-result-prefixes="#all"
+                version="2.0">
+   <xsl:import href="../../../../../style/crossQuery/resultFormatter/default/resultFormatter.xsl"/>
+
+   <!--Any declarations in this file take precedence over those in the stylesheet imported above.-->
+   <xsl:import href="../common/resultFormatterCommon.xsl"/>
+   <xsl:import href="rss.xsl"/>
+   <xsl:include href="searchForms.xsl"/>
+   <xsl:output method="xhtml"
+               indent="no"
+               encoding="UTF-8"
+               media-type="text/html; charset=UTF-8"
+               doctype-public="-//W3C//DTD XHTML 1.0 Transitional//EN"
+               doctype-system="http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"
+               omit-xml-declaration="yes"
+               exclude-result-prefixes="#all"/>
+</xsl:stylesheet>
+

--- a/local/style/crossQuery/resultFormatter/default/rss.xsl
+++ b/local/style/crossQuery/resultFormatter/default/rss.xsl
@@ -1,0 +1,17 @@
+<!--Local customization file for "rss.xsl"-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                xmlns:xtf="http://cdlib.org/xtf"
+                exclude-result-prefixes="#all"
+                version="2.0">
+   <xsl:import href="../../../../../style/crossQuery/resultFormatter/default/rss.xsl"/>
+
+   <!--Any declarations in this file take precedence over those in the stylesheet imported above.-->
+   <xsl:output method="xml"
+               name="rss-xml"
+               encoding="UTF-8"
+               media-type="text/xml"
+               indent="yes"
+               exclude-result-prefixes="#all"/>
+</xsl:stylesheet>
+

--- a/local/style/crossQuery/resultFormatter/default/searchForms.xsl
+++ b/local/style/crossQuery/resultFormatter/default/searchForms.xsl
@@ -1,0 +1,9 @@
+<!--Local customization file for "searchForms.xsl"-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns="http://www.w3.org/1999/xhtml"
+                version="2.0">
+   <xsl:import href="../../../../../style/crossQuery/resultFormatter/default/searchForms.xsl"/>
+
+   <!--Any declarations in this file take precedence over those in the stylesheet imported above.-->
+</xsl:stylesheet>
+

--- a/local/style/crossQuery/resultFormatter/oai/resultFormatter.xsl
+++ b/local/style/crossQuery/resultFormatter/oai/resultFormatter.xsl
@@ -1,0 +1,16 @@
+<!--Local customization file for "resultFormatter.xsl"-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:FileUtils="java:org.cdlib.xtf.xslt.FileUtils"
+                extension-element-prefixes="FileUtils"
+                exclude-result-prefixes="#all"
+                version="2.0">
+   <xsl:import href="../../../../../style/crossQuery/resultFormatter/oai/resultFormatter.xsl"/>
+
+   <!--Any declarations in this file take precedence over those in the stylesheet imported above.-->
+   <xsl:output method="xml"
+               encoding="UTF-8"
+               media-type="text/xml"
+               indent="yes"
+               exclude-result-prefixes="#all"/>
+</xsl:stylesheet>
+

--- a/local/style/crossQuery/resultFormatter/siteMap/resultFormatter.xsl
+++ b/local/style/crossQuery/resultFormatter/siteMap/resultFormatter.xsl
@@ -1,0 +1,15 @@
+<!--Local customization file for "resultFormatter.xsl"-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                exclude-result-prefixes="#all"
+                version="2.0">
+   <xsl:import href="../../../../../style/crossQuery/resultFormatter/siteMap/resultFormatter.xsl"/>
+
+   <!--Any declarations in this file take precedence over those in the stylesheet imported above.-->
+   <xsl:import href="../common/resultFormatterCommon.xsl"/>
+   <xsl:output method="xml"
+               encoding="UTF-8"
+               media-type="text/xml"
+               indent="yes"
+               exclude-result-prefixes="#all"/>
+</xsl:stylesheet>
+

--- a/local/style/dynaXML/docFormatter/bookreader/bookDocFormatter.xsl
+++ b/local/style/dynaXML/docFormatter/bookreader/bookDocFormatter.xsl
@@ -1,0 +1,27 @@
+<!--Local customization file for "bookDocFormatter.xsl"-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:xtf="http://cdlib.org/xtf"
+                xmlns:session="java:org.cdlib.xtf.xslt.Session"
+                xmlns:editURL="http://cdlib.org/xtf/editURL"
+                xmlns:local="http://local"
+                xmlns="http://www.w3.org/1999/xhtml"
+                version="2.0"
+                extension-element-prefixes="session"
+                exclude-result-prefixes="#all">
+   <xsl:import href="../../../../../style/dynaXML/docFormatter/bookreader/bookDocFormatter.xsl"/>
+
+   <!--Any declarations in this file take precedence over those in the stylesheet imported above.-->
+   <xsl:import href="../common/docFormatterCommon.xsl"/>
+   <xsl:import href="../../../xtfCommon/xtfCommon.xsl"/>
+   <xsl:output method="xhtml"
+               indent="yes"
+               encoding="UTF-8"
+               media-type="text/html; charset=UTF-8"
+               doctype-public="-//W3C//DTD XHTML 1.0 Transitional//EN"
+               doctype-system="http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"
+               exclude-result-prefixes="#all"
+               omit-xml-declaration="yes"/>
+   <xsl:strip-space elements="*"/>
+   <xsl:include href="search.xsl"/>
+</xsl:stylesheet>
+

--- a/local/style/dynaXML/docFormatter/bookreader/search.xsl
+++ b/local/style/dynaXML/docFormatter/bookreader/search.xsl
@@ -1,0 +1,12 @@
+<!--Local customization file for "search.xsl"-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:xtf="http://cdlib.org/xtf"
+                xmlns="http://www.w3.org/1999/xhtml"
+                xmlns:local="http://local"
+                version="2.0"
+                exclude-result-prefixes="#all">
+   <xsl:import href="../../../../../style/dynaXML/docFormatter/bookreader/search.xsl"/>
+
+   <!--Any declarations in this file take precedence over those in the stylesheet imported above.-->
+</xsl:stylesheet>
+

--- a/local/style/dynaXML/docFormatter/common/docFormatterCommon.xsl
+++ b/local/style/dynaXML/docFormatter/common/docFormatterCommon.xsl
@@ -1,0 +1,14 @@
+<!--Local customization file for "docFormatterCommon.xsl"-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:xtf="http://cdlib.org/xtf"
+                xmlns="http://www.w3.org/1999/xhtml"
+                xmlns:session="java:org.cdlib.xtf.xslt.Session"
+                version="2.0"
+                extension-element-prefixes="session"
+                exclude-result-prefixes="#all">
+   <xsl:import href="../../../../../style/dynaXML/docFormatter/common/docFormatterCommon.xsl"/>
+
+   <!--Any declarations in this file take precedence over those in the stylesheet imported above.-->
+   <xsl:import href="../../../xtfCommon/xtfCommon.xsl"/>
+</xsl:stylesheet>
+

--- a/local/style/dynaXML/docFormatter/ead/dsc4.xsl
+++ b/local/style/dynaXML/docFormatter/ead/dsc4.xsl
@@ -1,0 +1,10 @@
+<!--Local customization file for "dsc4.xsl"-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:xtf="http://cdlib.org/xtf"
+                xmlns="http://www.w3.org/1999/xhtml"
+                version="1.0">
+   <xsl:import href="../../../../../style/dynaXML/docFormatter/ead/dsc4.xsl"/>
+
+   <!--Any declarations in this file take precedence over those in the stylesheet imported above.-->
+</xsl:stylesheet>
+

--- a/local/style/dynaXML/docFormatter/ead/eadDocFormatter.xsl
+++ b/local/style/dynaXML/docFormatter/ead/eadDocFormatter.xsl
@@ -1,0 +1,35 @@
+<!--Local customization file for "eadDocFormatter.xsl"-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:xtf="http://cdlib.org/xtf"
+                xmlns="http://www.w3.org/1999/xhtml"
+                xmlns:session="java:org.cdlib.xtf.xslt.Session"
+                version="2.0"
+                extension-element-prefixes="session"
+                exclude-result-prefixes="#all">
+   <xsl:import href="../../../../../style/dynaXML/docFormatter/ead/eadDocFormatter.xsl"/>
+
+   <!--Any declarations in this file take precedence over those in the stylesheet imported above.-->
+   <xsl:import href="../common/docFormatterCommon.xsl"/>
+   <xsl:output method="xhtml"
+               indent="yes"
+               encoding="UTF-8"
+               media-type="text/html; charset=UTF-8"
+               doctype-public="-//W3C//DTD XHTML 1.0 Transitional//EN"
+               doctype-system="http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"
+               exclude-result-prefixes="#all"
+               omit-xml-declaration="yes"/>
+   <xsl:output name="frameset"
+               method="xhtml"
+               indent="yes"
+               encoding="UTF-8"
+               media-type="text/html; charset=UTF-8"
+               doctype-public="-//W3C//DTD XHTML 1.0 Frameset//EN"
+               doctype-system="http://www.w3.org/TR/xhtml1/DTD/xhtml1-frameset.dtd"
+               omit-xml-declaration="yes"
+               exclude-result-prefixes="#all"/>
+   <xsl:strip-space elements="*"/>
+   <xsl:include href="eadcbs7.xsl"/>
+   <xsl:include href="parameter.xsl"/>
+   <xsl:include href="search.xsl"/>
+</xsl:stylesheet>
+

--- a/local/style/dynaXML/docFormatter/ead/eadcbs7.xsl
+++ b/local/style/dynaXML/docFormatter/ead/eadcbs7.xsl
@@ -1,0 +1,11 @@
+<!--Local customization file for "eadcbs7.xsl"-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:xtf="http://cdlib.org/xtf"
+                xmlns="http://www.w3.org/1999/xhtml"
+                version="1.0">
+   <xsl:import href="../../../../../style/dynaXML/docFormatter/ead/eadcbs7.xsl"/>
+
+   <!--Any declarations in this file take precedence over those in the stylesheet imported above.-->
+   <xsl:include href="dsc4.xsl"/>
+</xsl:stylesheet>
+

--- a/local/style/dynaXML/docFormatter/ead/parameter.xsl
+++ b/local/style/dynaXML/docFormatter/ead/parameter.xsl
@@ -1,0 +1,10 @@
+<!--Local customization file for "parameter.xsl"-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:xtf="http://cdlib.org/xtf"
+                xmlns="http://www.w3.org/1999/xhtml"
+                version="2.0">
+   <xsl:import href="../../../../../style/dynaXML/docFormatter/ead/parameter.xsl"/>
+
+   <!--Any declarations in this file take precedence over those in the stylesheet imported above.-->
+</xsl:stylesheet>
+

--- a/local/style/dynaXML/docFormatter/ead/search.xsl
+++ b/local/style/dynaXML/docFormatter/ead/search.xsl
@@ -1,0 +1,10 @@
+<!--Local customization file for "search.xsl"-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:xtf="http://cdlib.org/xtf"
+                xmlns="http://www.w3.org/1999/xhtml"
+                version="2.0">
+   <xsl:import href="../../../../../style/dynaXML/docFormatter/ead/search.xsl"/>
+
+   <!--Any declarations in this file take precedence over those in the stylesheet imported above.-->
+</xsl:stylesheet>
+

--- a/local/style/dynaXML/docFormatter/erc/ercDocFormatter.xsl
+++ b/local/style/dynaXML/docFormatter/erc/ercDocFormatter.xsl
@@ -1,0 +1,13 @@
+<!--Local customization file for "ercDocFormatter.xsl"-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:xtf="http://cdlib.org/xtf"
+                version="2.0"
+                exclude-result-prefixes="#all">
+   <xsl:import href="../../../../../style/dynaXML/docFormatter/erc/ercDocFormatter.xsl"/>
+
+   <!--Any declarations in this file take precedence over those in the stylesheet imported above.-->
+   <xsl:output method="text"
+               encoding="UTF-8"
+               media-type="text/plain; charset=UTF-8"/>
+</xsl:stylesheet>
+

--- a/local/style/dynaXML/docFormatter/nlm/ViewNLM-v2.3.xsl
+++ b/local/style/dynaXML/docFormatter/nlm/ViewNLM-v2.3.xsl
@@ -1,0 +1,15 @@
+<!--Local customization file for "ViewNLM-v2.3.xsl"-->
+<xsl:transform xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+               xmlns:xlink="http://www.w3.org/1999/xlink"
+               xmlns:util="http://dtd.nlm.nih.gov/xsl/util"
+               xmlns:mml="http://www.w3.org/1998/Math/MathML"
+               xmlns="http://www.w3.org/1999/xhtml"
+               version="2.0"
+               id="ViewNLM-v2-04.xsl"
+               exclude-result-prefixes="#all">
+   <xsl:import href="../../../../../style/dynaXML/docFormatter/nlm/ViewNLM-v2.3.xsl"/>
+
+   <!--Any declarations in this file take precedence over those in the stylesheet imported above.-->
+   <xsl:strip-space elements="*"/>
+</xsl:transform>
+

--- a/local/style/dynaXML/docFormatter/nlm/nlmDocFormatter.xsl
+++ b/local/style/dynaXML/docFormatter/nlm/nlmDocFormatter.xsl
@@ -1,0 +1,34 @@
+<!--Local customization file for "nlmDocFormatter.xsl"-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:xtf="http://cdlib.org/xtf"
+                xmlns:session="java:org.cdlib.xtf.xslt.Session"
+                xmlns="http://www.w3.org/1999/xhtml"
+                version="2.0"
+                extension-element-prefixes="session"
+                exclude-result-prefixes="#all">
+   <xsl:import href="../../../../../style/dynaXML/docFormatter/nlm/nlmDocFormatter.xsl"/>
+
+   <!--Any declarations in this file take precedence over those in the stylesheet imported above.-->
+   <xsl:import href="../common/docFormatterCommon.xsl"/>
+   <xsl:output method="xhtml"
+               indent="no"
+               encoding="UTF-8"
+               media-type="text/html; charset=UTF-8"
+               doctype-public="-//W3C//DTD XHTML 1.0 Transitional//EN"
+               doctype-system="http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"
+               exclude-result-prefixes="#all"
+               omit-xml-declaration="yes"/>
+   <xsl:output name="frameset"
+               method="xhtml"
+               indent="no"
+               encoding="UTF-8"
+               media-type="text/html; charset=UTF-8"
+               doctype-public="-//W3C//DTD XHTML 1.0 Frameset//EN"
+               doctype-system="http://www.w3.org/TR/xhtml1/DTD/xhtml1-frameset.dtd"
+               omit-xml-declaration="yes"
+               exclude-result-prefixes="#all"/>
+   <xsl:strip-space elements="*"/>
+   <xsl:include href="ViewNLM-v2.3.xsl"/>
+   <xsl:include href="search.xsl"/>
+</xsl:stylesheet>
+

--- a/local/style/dynaXML/docFormatter/nlm/search.xsl
+++ b/local/style/dynaXML/docFormatter/nlm/search.xsl
@@ -1,0 +1,10 @@
+<!--Local customization file for "search.xsl"-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:xtf="http://cdlib.org/xtf"
+                xmlns="http://www.w3.org/1999/xhtml"
+                version="2.0">
+   <xsl:import href="../../../../../style/dynaXML/docFormatter/nlm/search.xsl"/>
+
+   <!--Any declarations in this file take precedence over those in the stylesheet imported above.-->
+</xsl:stylesheet>
+

--- a/local/style/dynaXML/docFormatter/tei/autotoc.xsl
+++ b/local/style/dynaXML/docFormatter/tei/autotoc.xsl
@@ -1,0 +1,11 @@
+<!--Local customization file for "autotoc.xsl"-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:xtf="http://cdlib.org/xtf"
+                xmlns="http://www.w3.org/1999/xhtml"
+                version="2.0"
+                exclude-result-prefixes="#all">
+   <xsl:import href="../../../../../style/dynaXML/docFormatter/tei/autotoc.xsl"/>
+
+   <!--Any declarations in this file take precedence over those in the stylesheet imported above.-->
+</xsl:stylesheet>
+

--- a/local/style/dynaXML/docFormatter/tei/component.xsl
+++ b/local/style/dynaXML/docFormatter/tei/component.xsl
@@ -1,0 +1,10 @@
+<!--Local customization file for "component.xsl"-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns="http://www.w3.org/1999/xhtml"
+                version="2.0"
+                exclude-result-prefixes="#all">
+   <xsl:import href="../../../../../style/dynaXML/docFormatter/tei/component.xsl"/>
+
+   <!--Any declarations in this file take precedence over those in the stylesheet imported above.-->
+</xsl:stylesheet>
+

--- a/local/style/dynaXML/docFormatter/tei/parameter.xsl
+++ b/local/style/dynaXML/docFormatter/tei/parameter.xsl
@@ -1,0 +1,10 @@
+<!--Local customization file for "parameter.xsl"-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns="http://www.w3.org/1999/xhtml"
+                version="2.0"
+                exclude-result-prefixes="#all">
+   <xsl:import href="../../../../../style/dynaXML/docFormatter/tei/parameter.xsl"/>
+
+   <!--Any declarations in this file take precedence over those in the stylesheet imported above.-->
+</xsl:stylesheet>
+

--- a/local/style/dynaXML/docFormatter/tei/search.xsl
+++ b/local/style/dynaXML/docFormatter/tei/search.xsl
@@ -1,0 +1,11 @@
+<!--Local customization file for "search.xsl"-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:xtf="http://cdlib.org/xtf"
+                xmlns="http://www.w3.org/1999/xhtml"
+                version="2.0"
+                exclude-result-prefixes="#all">
+   <xsl:import href="../../../../../style/dynaXML/docFormatter/tei/search.xsl"/>
+
+   <!--Any declarations in this file take precedence over those in the stylesheet imported above.-->
+</xsl:stylesheet>
+

--- a/local/style/dynaXML/docFormatter/tei/structure.xsl
+++ b/local/style/dynaXML/docFormatter/tei/structure.xsl
@@ -1,0 +1,10 @@
+<!--Local customization file for "structure.xsl"-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns="http://www.w3.org/1999/xhtml"
+                version="2.0"
+                exclude-result-prefixes="#all">
+   <xsl:import href="../../../../../style/dynaXML/docFormatter/tei/structure.xsl"/>
+
+   <!--Any declarations in this file take precedence over those in the stylesheet imported above.-->
+</xsl:stylesheet>
+

--- a/local/style/dynaXML/docFormatter/tei/table.xsl
+++ b/local/style/dynaXML/docFormatter/tei/table.xsl
@@ -1,0 +1,10 @@
+<!--Local customization file for "table.xsl"-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns="http://www.w3.org/1999/xhtml"
+                version="2.0"
+                exclude-result-prefixes="#all">
+   <xsl:import href="../../../../../style/dynaXML/docFormatter/tei/table.xsl"/>
+
+   <!--Any declarations in this file take precedence over those in the stylesheet imported above.-->
+</xsl:stylesheet>
+

--- a/local/style/dynaXML/docFormatter/tei/teiDocFormatter.xsl
+++ b/local/style/dynaXML/docFormatter/tei/teiDocFormatter.xsl
@@ -1,0 +1,39 @@
+<!--Local customization file for "teiDocFormatter.xsl"-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:xtf="http://cdlib.org/xtf"
+                xmlns="http://www.w3.org/1999/xhtml"
+                xmlns:session="java:org.cdlib.xtf.xslt.Session"
+                version="2.0"
+                extension-element-prefixes="session"
+                exclude-result-prefixes="#all">
+   <xsl:import href="../../../../../style/dynaXML/docFormatter/tei/teiDocFormatter.xsl"/>
+
+   <!--Any declarations in this file take precedence over those in the stylesheet imported above.-->
+   <xsl:import href="../common/docFormatterCommon.xsl"/>
+   <xsl:output method="xhtml"
+               indent="no"
+               encoding="UTF-8"
+               media-type="text/html; charset=UTF-8"
+               doctype-public="-//W3C//DTD XHTML 1.0 Transitional//EN"
+               doctype-system="http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"
+               exclude-result-prefixes="#all"
+               omit-xml-declaration="yes"/>
+   <xsl:output name="frameset"
+               method="xhtml"
+               indent="no"
+               encoding="UTF-8"
+               media-type="text/html; charset=UTF-8"
+               doctype-public="-//W3C//DTD XHTML 1.0 Frameset//EN"
+               doctype-system="http://www.w3.org/TR/xhtml1/DTD/xhtml1-frameset.dtd"
+               omit-xml-declaration="yes"
+               exclude-result-prefixes="#all"/>
+   <xsl:strip-space elements="*"/>
+   <xsl:include href="autotoc.xsl"/>
+   <xsl:include href="component.xsl"/>
+   <xsl:include href="search.xsl"/>
+   <xsl:include href="parameter.xsl"/>
+   <xsl:include href="structure.xsl"/>
+   <xsl:include href="table.xsl"/>
+   <xsl:include href="titlepage.xsl"/>
+</xsl:stylesheet>
+

--- a/local/style/dynaXML/docFormatter/tei/titlepage.xsl
+++ b/local/style/dynaXML/docFormatter/tei/titlepage.xsl
@@ -1,0 +1,10 @@
+<!--Local customization file for "titlepage.xsl"-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns="http://www.w3.org/1999/xhtml"
+                version="2.0"
+                exclude-result-prefixes="#all">
+   <xsl:import href="../../../../../style/dynaXML/docFormatter/tei/titlepage.xsl"/>
+
+   <!--Any declarations in this file take precedence over those in the stylesheet imported above.-->
+</xsl:stylesheet>
+

--- a/local/style/dynaXML/docReqParser.xsl
+++ b/local/style/dynaXML/docReqParser.xsl
@@ -1,0 +1,18 @@
+<!--Local customization file for "docReqParser.xsl"-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:dc="http://purl.org/dc/elements/1.1/"
+                xmlns:mets="http://www.loc.gov/METS/"
+                xmlns:mods="http://www.loc.gov/mods/"
+                xmlns:xlink="http://www.w3.org/TR/xlink"
+                xmlns:parse="http://cdlib.org/parse"
+                xmlns:FileUtils="java:org.cdlib.xtf.xslt.FileUtils"
+                version="2.0"
+                extension-element-prefixes="FileUtils"
+                exclude-result-prefixes="#all">
+   <xsl:import href="../../../style/dynaXML/docReqParser.xsl"/>
+
+   <!--Any declarations in this file take precedence over those in the stylesheet imported above.-->
+   <xsl:import href="../crossQuery/queryParser/default/queryParser.xsl"/>
+   <xsl:output method="xml" indent="yes" encoding="utf-8"/>
+</xsl:stylesheet>
+

--- a/local/style/dynaXML/errorGen.xsl
+++ b/local/style/dynaXML/errorGen.xsl
@@ -1,0 +1,15 @@
+<!--Local customization file for "errorGen.xsl"-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">
+   <xsl:import href="../../../style/dynaXML/errorGen.xsl"/>
+
+   <!--Any declarations in this file take precedence over those in the stylesheet imported above.-->
+   <xsl:output method="xhtml"
+               indent="no"
+               encoding="UTF-8"
+               media-type="text/html; charset=UTF-8"
+               doctype-public="-//W3C//DTD XHTML 1.0 Transitional//EN"
+               doctype-system="http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"
+               exclude-result-prefixes="#all"
+               omit-xml-declaration="yes"/>
+</xsl:stylesheet>
+

--- a/local/style/sru/errorGen.xsl
+++ b/local/style/sru/errorGen.xsl
@@ -1,0 +1,14 @@
+<!--Local customization file for "errorGen.xsl"-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:srw="http://www.loc.gov/zing/srw/"
+                xmlns:diag="http://www.loc.gov/zing/srw/diagnostic/"
+                version="1.0">
+   <xsl:import href="../../../style/sru/errorGen.xsl"/>
+
+   <!--Any declarations in this file take precedence over those in the stylesheet imported above.-->
+   <xsl:output method="xml"
+               indent="yes"
+               encoding="utf-8"
+               media-type="text/xml"/>
+</xsl:stylesheet>
+

--- a/local/style/sru/queryParser.xsl
+++ b/local/style/sru/queryParser.xsl
@@ -1,0 +1,21 @@
+<!--Local customization file for "queryParser.xsl"-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:dc="http://purl.org/dc/elements/1.1/"
+                xmlns:mets="http://www.loc.gov/METS/"
+                xmlns:xlink="http://www.w3.org/TR/xlink"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                xmlns:parse="http://cdlib.org/parse"
+                xmlns:srw="http://www.loc.gov/zing/srw/"
+                xmlns:diag="http://www.loc.gov/zing/srw/diagnostic/"
+                xmlns:xcql="http://www.loc.gov/zing/srw/xcql/"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema"
+                xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
+                version="2.0"
+                exclude-result-prefixes="xsl dc mets xlink xs parse">
+   <xsl:import href="../../../style/sru/queryParser.xsl"/>
+
+   <!--Any declarations in this file take precedence over those in the stylesheet imported above.-->
+   <xsl:output method="xml" indent="yes" encoding="utf-8"/>
+   <xsl:strip-space elements="*"/>
+</xsl:stylesheet>
+

--- a/local/style/sru/resultFormatter/resultFormatter.xsl
+++ b/local/style/sru/resultFormatter/resultFormatter.xsl
@@ -1,0 +1,16 @@
+<!--Local customization file for "resultFormatter.xsl"-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema"
+                xmlns:dc="http://purl.org/dc/elements/1.1/"
+                xmlns:srw="http://www.loc.gov/zing/srw/"
+                xmlns:srw_dc="info:srw/schema/1/dc-schema"
+                version="2.0">
+   <xsl:import href="../../../../style/sru/resultFormatter/resultFormatter.xsl"/>
+
+   <!--Any declarations in this file take precedence over those in the stylesheet imported above.-->
+   <xsl:output method="xml"
+               indent="yes"
+               encoding="UTF-8"
+               media-type="text/xml"/>
+</xsl:stylesheet>
+

--- a/local/style/textIndexer/bookreader/bookPreFilter.xsl
+++ b/local/style/textIndexer/bookreader/bookPreFilter.xsl
@@ -1,0 +1,20 @@
+<!--Local customization file for "bookPreFilter.xsl"-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:FileUtils="java:org.cdlib.xtf.xslt.FileUtils"
+                xmlns:local="http://cdlib.org/local"
+                xmlns:METS="http://www.loc.gov/METS/"
+                xmlns:parse="http://cdlib.org/xtf/parse"
+                xmlns:saxon="http://saxon.sf.net/"
+                xmlns:scribe="http://archive.org/scribe/xml"
+                xmlns:xlink="http://www.w3.org/1999/xlink"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                xmlns:xtf="http://cdlib.org/xtf"
+                version="2.0"
+                exclude-result-prefixes="#all">
+   <xsl:import href="../../../../style/textIndexer/bookreader/bookPreFilter.xsl"/>
+
+   <!--Any declarations in this file take precedence over those in the stylesheet imported above.-->
+   <xsl:import href="../common/preFilterCommon.xsl"/>
+   <xsl:output method="xml" indent="yes" encoding="UTF-8"/>
+</xsl:stylesheet>
+

--- a/local/style/textIndexer/common/preFilterCommon.xsl
+++ b/local/style/textIndexer/common/preFilterCommon.xsl
@@ -1,0 +1,17 @@
+<!--Local customization file for "preFilterCommon.xsl"-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:dc="http://purl.org/dc/elements/1.1/"
+                xmlns:expand="http://cdlib.org/xtf/expand"
+                xmlns:parse="http://cdlib.org/xtf/parse"
+                xmlns:xtf="http://cdlib.org/xtf"
+                xmlns:saxon="http://saxon.sf.net/"
+                xmlns:FileUtils="java:org.cdlib.xtf.xslt.FileUtils"
+                xmlns:CharUtils="java:org.cdlib.xtf.xslt.CharUtils"
+                version="2.0"
+                extension-element-prefixes="saxon FileUtils"
+                exclude-result-prefixes="#all">
+   <xsl:import href="../../../../style/textIndexer/common/preFilterCommon.xsl"/>
+
+   <!--Any declarations in this file take precedence over those in the stylesheet imported above.-->
+</xsl:stylesheet>
+

--- a/local/style/textIndexer/default/defaultPreFilter.xsl
+++ b/local/style/textIndexer/default/defaultPreFilter.xsl
@@ -1,0 +1,12 @@
+<!--Local customization file for "defaultPreFilter.xsl"-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:xtf="http://cdlib.org/xtf"
+                version="2.0"
+                exclude-result-prefixes="#all">
+   <xsl:import href="../../../../style/textIndexer/default/defaultPreFilter.xsl"/>
+
+   <!--Any declarations in this file take precedence over those in the stylesheet imported above.-->
+   <xsl:import href="../common/preFilterCommon.xsl"/>
+   <xsl:output method="xml" indent="yes" encoding="UTF-8"/>
+</xsl:stylesheet>
+

--- a/local/style/textIndexer/docSelector.xsl
+++ b/local/style/textIndexer/docSelector.xsl
@@ -1,0 +1,11 @@
+<!--Local customization file for "docSelector.xsl"-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:FileUtils="java:org.cdlib.xtf.xslt.FileUtils"
+                version="2.0"
+                extension-element-prefixes="FileUtils"
+                exclude-result-prefixes="#all">
+   <xsl:import href="../../../style/textIndexer/docSelector.xsl"/>
+
+   <!--Any declarations in this file take precedence over those in the stylesheet imported above.-->
+</xsl:stylesheet>
+

--- a/local/style/textIndexer/ead/at2oac.xsl
+++ b/local/style/textIndexer/ead/at2oac.xsl
@@ -1,0 +1,12 @@
+<!--Local customization file for "at2oac.xsl"-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xmlns:ead="urn:isbn:1-931666-22-9"
+                xmlns:xlink="http://www.w3.org/1999/xlink"
+                xmlns="urn:isbn:1-931666-22-9"
+                version="1.0">
+   <xsl:import href="../../../../style/textIndexer/ead/at2oac.xsl"/>
+
+   <!--Any declarations in this file take precedence over those in the stylesheet imported above.-->
+</xsl:stylesheet>
+

--- a/local/style/textIndexer/ead/eadPreFilter.xsl
+++ b/local/style/textIndexer/ead/eadPreFilter.xsl
@@ -1,0 +1,16 @@
+<!--Local customization file for "eadPreFilter.xsl"-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                xmlns:parse="http://cdlib.org/xtf/parse"
+                xmlns:xtf="http://cdlib.org/xtf"
+                version="2.0"
+                exclude-result-prefixes="#all">
+   <xsl:import href="../../../../style/textIndexer/ead/eadPreFilter.xsl"/>
+
+   <!--Any declarations in this file take precedence over those in the stylesheet imported above.-->
+   <xsl:import href="../common/preFilterCommon.xsl"/>
+   <xsl:import href="./supplied-headings.xsl"/>
+   <xsl:import href="./at2oac.xsl"/>
+   <xsl:output method="xml" indent="yes" encoding="UTF-8"/>
+</xsl:stylesheet>
+

--- a/local/style/textIndexer/ead/supplied-headings.xsl
+++ b/local/style/textIndexer/ead/supplied-headings.xsl
@@ -1,0 +1,9 @@
+<!--Local customization file for "supplied-headings.xsl"-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:oac="http://oac.cdlib.org"
+                version="2.0">
+   <xsl:import href="../../../../style/textIndexer/ead/supplied-headings.xsl"/>
+
+   <!--Any declarations in this file take precedence over those in the stylesheet imported above.-->
+</xsl:stylesheet>
+

--- a/local/style/textIndexer/html/htmlPreFilter.xsl
+++ b/local/style/textIndexer/html/htmlPreFilter.xsl
@@ -1,0 +1,15 @@
+<!--Local customization file for "htmlPreFilter.xsl"-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:parse="http://cdlib.org/xtf/parse"
+                xmlns:xtf="http://cdlib.org/xtf"
+                xmlns:saxon="http://saxon.sf.net/"
+                version="2.0"
+                extension-element-prefixes="saxon"
+                exclude-result-prefixes="#all">
+   <xsl:import href="../../../../style/textIndexer/html/htmlPreFilter.xsl"/>
+
+   <!--Any declarations in this file take precedence over those in the stylesheet imported above.-->
+   <xsl:import href="../common/preFilterCommon.xsl"/>
+   <xsl:output method="xml" indent="yes" encoding="UTF-8"/>
+</xsl:stylesheet>
+

--- a/local/style/textIndexer/nlm/nlmPreFilter.xsl
+++ b/local/style/textIndexer/nlm/nlmPreFilter.xsl
@@ -1,0 +1,14 @@
+<!--Local customization file for "nlmPreFilter.xsl"-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:parse="http://cdlib.org/xtf/parse"
+                xmlns:xlink="http://www.w3.org/TR/xlink/"
+                xmlns:xtf="http://cdlib.org/xtf"
+                version="2.0"
+                exclude-result-prefixes="#all">
+   <xsl:import href="../../../../style/textIndexer/nlm/nlmPreFilter.xsl"/>
+
+   <!--Any declarations in this file take precedence over those in the stylesheet imported above.-->
+   <xsl:import href="../common/preFilterCommon.xsl"/>
+   <xsl:output method="xml" indent="yes" encoding="UTF-8"/>
+</xsl:stylesheet>
+

--- a/local/style/textIndexer/tei/teiPreFilter.xsl
+++ b/local/style/textIndexer/tei/teiPreFilter.xsl
@@ -1,0 +1,16 @@
+<!--Local customization file for "teiPreFilter.xsl"-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:date="http://exslt.org/dates-and-times"
+                xmlns:parse="http://cdlib.org/xtf/parse"
+                xmlns:xtf="http://cdlib.org/xtf"
+                xmlns:FileUtils="java:org.cdlib.xtf.xslt.FileUtils"
+                version="2.0"
+                extension-element-prefixes="date FileUtils"
+                exclude-result-prefixes="#all">
+   <xsl:import href="../../../../style/textIndexer/tei/teiPreFilter.xsl"/>
+
+   <!--Any declarations in this file take precedence over those in the stylesheet imported above.-->
+   <xsl:import href="../common/preFilterCommon.xsl"/>
+   <xsl:output method="xml" indent="yes" encoding="UTF-8"/>
+</xsl:stylesheet>
+

--- a/local/style/xtfCommon/xtfCommon.xsl
+++ b/local/style/xtfCommon/xtfCommon.xsl
@@ -1,0 +1,14 @@
+<!--Local customization file for "xtfCommon.xsl"-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:xtf="http://cdlib.org/xtf"
+                xmlns:session="java:org.cdlib.xtf.xslt.Session"
+                xmlns:editURL="http://cdlib.org/xtf/editURL"
+                xmlns="http://www.w3.org/1999/xhtml"
+                extension-element-prefixes="session"
+                exclude-result-prefixes="#all"
+                version="2.0">
+   <xsl:import href="../../../style/xtfCommon/xtfCommon.xsl"/>
+
+   <!--Any declarations in this file take precedence over those in the stylesheet imported above.-->
+</xsl:stylesheet>
+

--- a/profiles/display/defaultDisplayMech.xml
+++ b/profiles/display/defaultDisplayMech.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <displayMech ID="default">
-   <style path="style/dynaXML/docFormatter/default/docFormatter.xsl"/>
+   <style path="local/style/dynaXML/docFormatter/default/docFormatter.xsl"/>
 </displayMech>

--- a/regress/endToEnd/test1/conf/crossQuery.conf
+++ b/regress/endToEnd/test1/conf/crossQuery.conf
@@ -6,8 +6,8 @@
 
 <crossQuery-config>
     <logging level="info"/>
-    <queryRouter path="style/crossQuery/queryRouter.xsl"/>
-    <errorGen path="style/crossQuery/errorGen.xsl"/>
+    <queryRouter path="local/style/crossQuery/queryRouter.xsl"/>
+    <errorGen path="local/style/crossQuery/errorGen.xsl"/>
     <stylesheetCache size="10" expire="0"/>
     <dependencyChecking check="yes"/>
     <reportLatency enable="yes" cutoffSize="0"/>

--- a/regress/endToEnd/test1/conf/dynaXML.conf
+++ b/regress/endToEnd/test1/conf/dynaXML.conf
@@ -6,8 +6,8 @@
 
 <dynaXML-config>
     <logging level="info"/>
-    <docReqParser path="style/dynaXML/docReqParser.xsl"/>
-    <errorGen path="style/dynaXML/errorGen.xsl"/>
+    <docReqParser path="local/style/dynaXML/docReqParser.xsl"/>
+    <errorGen path="local/style/dynaXML/errorGen.xsl"/>
     <stylesheetCache size="10" expire="0"/>
     <ipListCache size="30" expire="0"/>
     <authCache size="1000" expire="1800"/>

--- a/regress/endToEnd/test1/style/crossQuery/queryRouter.xsl
+++ b/regress/endToEnd/test1/style/crossQuery/queryRouter.xsl
@@ -4,8 +4,8 @@
    
    <xsl:template match="/">
       <route>
-         <queryParser path="style/crossQuery/queryParser.xsl"/>
-         <errorGen path="style/crossQuery/errorGen.xsl"/>
+         <queryParser path="local/style/crossQuery/queryParser.xsl"/>
+         <errorGen path="local/style/crossQuery/errorGen.xsl"/>
       </route>
    </xsl:template>
    

--- a/regress/endToEnd/test1/style/dynaXML/docReqParser.xsl
+++ b/regress/endToEnd/test1/style/dynaXML/docReqParser.xsl
@@ -31,10 +31,10 @@
    <!-- ====================================================================== -->
    
    <xsl:template match="/">
-      <style path="style/dynaXML/docFormatter.xsl"/>
+      <style path="local/style/dynaXML/docFormatter.xsl"/>
       <source path="{concat('data/',$docId)}"/>
       <index configPath="conf/textIndexer.conf" name="default"/>
-      <preFilter path="style/textIndexer/preFilter.xsl"/>
+      <preFilter path="local/style/textIndexer/preFilter.xsl"/>
 
       <xsl:if test="$query != '0' and $query != ''">
          

--- a/regress/endToEnd/test1/style/textIndexer/docSelector.xsl
+++ b/regress/endToEnd/test1/style/textIndexer/docSelector.xsl
@@ -14,8 +14,8 @@
    <xsl:template match="file">
       <xsl:if test="ends-with(@fileName, '.xml')">
          <indexFile fileName="{@fileName}"
-                    preFilter="style/textIndexer/preFilter.xsl"
-                    displayStyle="style/dynaXML/docFormatter.xsl"/>
+                    preFilter="local/style/textIndexer/preFilter.xsl"
+                    displayStyle="local/style/dynaXML/docFormatter.xsl"/>
        </xsl:if>
    </xsl:template>
 

--- a/style/crossQuery/queryParser/oai/queryParser.xsl
+++ b/style/crossQuery/queryParser/oai/queryParser.xsl
@@ -181,7 +181,7 @@
             <error message="OAI::{$verb}::badResumptionToken::{$badResumptionTokenMessage}"/>
          </xsl:when>
          <xsl:when test="string-length($resumptionToken) &gt; 0">
-            <query indexPath="index" maxDocs="1" startDoc="1"  style="style/crossQuery/resultFormatter/oai/resultFormatter.xsl">
+            <query indexPath="index" maxDocs="1" startDoc="1"  style="local/style/crossQuery/resultFormatter/oai/resultFormatter.xsl">
                <allDocs/>
             </query>
          </xsl:when>
@@ -290,7 +290,7 @@
    
    <!-- construct query -->
    <xsl:template name="query">
-      <query indexPath="index" maxDocs="{$maxDocs}" startDoc="{$startDoc}" sortMetaFields="dateStamp" style="style/crossQuery/resultFormatter/oai/resultFormatter.xsl" termLimit="1000" workLimit="1000000">
+      <query indexPath="index" maxDocs="{$maxDocs}" startDoc="{$startDoc}" sortMetaFields="dateStamp" style="local/style/crossQuery/resultFormatter/oai/resultFormatter.xsl" termLimit="1000" workLimit="1000000">
          <xsl:choose>
             <xsl:when test="$verb='GetRecord'">
                <and field="identifier">

--- a/style/crossQuery/queryRouter.xsl
+++ b/style/crossQuery/queryRouter.xsl
@@ -61,16 +61,16 @@
          <xsl:choose>
             <!-- oai -->
             <xsl:when test="matches($http.URL,'oai\?')">
-               <queryParser path="style/crossQuery/queryParser/oai/queryParser.xsl"/>
-               <errorGen path="style/crossQuery/oaiErrorGen.xsl"/>
+               <queryParser path="local/style/crossQuery/queryParser/oai/queryParser.xsl"/>
+               <errorGen path="local/style/crossQuery/oaiErrorGen.xsl"/>
             </xsl:when>
             <!-- sitemap -->
             <xsl:when test="matches($smode,'siteMap')">
-               <queryParser path="style/crossQuery/queryParser/siteMap/queryParser.xsl"/>
+               <queryParser path="local/style/crossQuery/queryParser/siteMap/queryParser.xsl"/>
             </xsl:when>
             <!-- default -->
             <xsl:otherwise>
-               <queryParser path="style/crossQuery/queryParser/default/queryParser.xsl"/>
+               <queryParser path="local/style/crossQuery/queryParser/default/queryParser.xsl"/>
             </xsl:otherwise>
          </xsl:choose>
       </route>

--- a/style/crossQuery/resultFormatter/common/format-query.xsl
+++ b/style/crossQuery/resultFormatter/common/format-query.xsl
@@ -127,7 +127,7 @@
             </b>
             <xsl:text>&#160;</xsl:text>
             <!-- query removal widget -->
-            <a href="{$xtfURL}{$crossqueryPath}?{editURL:clean($finalString)}">[X]</a>
+            <a href="{$crossqueryPath}?{editURL:clean($finalString)}">[X]</a>
             <br/>
          </xsl:when>
          

--- a/style/crossQuery/resultFormatter/common/resultFormatterCommon.xsl
+++ b/style/crossQuery/resultFormatter/common/resultFormatterCommon.xsl
@@ -397,14 +397,14 @@
          <!-- Individual Paging -->
          <xsl:if test="($pageNum = 1) and ($pageStart != $start)">
             <xsl:variable name="prevPage" as="xs:integer" select="$start - $perPage"/>
-            <a href="{$xtfURL}{$crossqueryPath}?{$pageQueryString};{$startName}={$prevPage}">Prev</a>
+            <a href="{$crossqueryPath}?{$pageQueryString};{$startName}={$prevPage}">Prev</a>
             <xsl:text>&#160;&#160;</xsl:text>
          </xsl:if>
          
          <!-- Paging by Blocks -->
          <xsl:variable name="prevBlock" as="xs:integer" select="(($blockStart - $blockSize) * $perPage) - ($perPage - 1)"/>
          <xsl:if test="($pageNum = 1) and ($prevBlock &gt;= 1)">
-            <a href="{$xtfURL}{$crossqueryPath}?{$pageQueryString};{$startName}={$prevBlock}">...</a>
+            <a href="{$crossqueryPath}?{$pageQueryString};{$startName}={$prevBlock}">...</a>
             <xsl:text>&#160;&#160;</xsl:text>
          </xsl:if>
          
@@ -414,7 +414,7 @@
             <xsl:choose>
                <!-- Make a hyperlink if it's not the page we're currently on. -->
                <xsl:when test="($pageStart != $start)">
-                  <a href="{$xtfURL}{$crossqueryPath}?{$pageQueryString};{$startName}={$pageStart}">
+                  <a href="{$crossqueryPath}?{$pageQueryString};{$startName}={$pageStart}">
                      <xsl:value-of select="$pageNum"/>
                   </a>
                   <xsl:if test="$pageNum &lt; $showPages">
@@ -434,14 +434,14 @@
          <xsl:variable name="nextBlock" as="xs:integer" select="(($blockStart + $blockSize) * $perPage) - ($perPage - 1)"/>
          <xsl:if test="($pageNum = $showPages) and (($showPages * $perPage) &gt; $nextBlock)">
             <xsl:text>&#160;&#160;</xsl:text>
-            <a href="{$xtfURL}{$crossqueryPath}?{$pageQueryString};{$startName}={$nextBlock}">...</a>
+            <a href="{$crossqueryPath}?{$pageQueryString};{$startName}={$nextBlock}">...</a>
          </xsl:if>
          
          <!-- Individual Paging -->      
          <xsl:if test="($pageNum = $showPages) and ($pageStart != $start)">
             <xsl:variable name="nextPage" as="xs:integer" select="$start + $perPage"/>
             <xsl:text>&#160;&#160;</xsl:text>
-            <a href="{$xtfURL}{$crossqueryPath}?{$pageQueryString};{$startName}={$nextPage}">Next</a>
+            <a href="{$crossqueryPath}?{$pageQueryString};{$startName}={$nextPage}">Next</a>
          </xsl:if>
          
       </xsl:for-each>
@@ -453,7 +453,7 @@
    <!-- ====================================================================== -->
    
    <xsl:template match="subject">
-      <a href="{$xtfURL}{$crossqueryPath}?subject={editURL:protectValue(.)};subject-join=exact;smode={$smode};rmode={$rmode};style={$style};brand={$brand}">
+      <a href="{$crossqueryPath}?subject={editURL:protectValue(.)};subject-join=exact;smode={$smode};rmode={$rmode};style={$style};brand={$brand}">
          <xsl:apply-templates/>
       </a>
       <xsl:if test="not(position() = last())">
@@ -476,7 +476,7 @@
          <xsl:when test="(contains($rmode, 'showDescrip')) and (matches($string , '.{500}'))">
             <xsl:apply-templates select="$block"/>
             <xsl:text>&#160;&#160;&#160;</xsl:text>
-            <a href="{$xtfURL}{$crossqueryPath}?{$hideString};startDoc={$startDoc};rmode=hideDescrip#{$identifier}">[brief]</a>         
+            <a href="{$crossqueryPath}?{$hideString};startDoc={$startDoc};rmode=hideDescrip#{$identifier}">[brief]</a>         
          </xsl:when>
          <xsl:otherwise>
             <xsl:apply-templates select="$block" mode="crop">
@@ -497,7 +497,7 @@
          <xsl:when test="matches($string , '.{300}')">
             <xsl:value-of select="replace($string, '(.{300}).+', '$1')"/>
             <xsl:text> . . . </xsl:text>
-            <a href="{$xtfURL}{$crossqueryPath}?{$moreString};startDoc={$startDoc};rmode=showDescrip#{$identifier}">[more]</a>  
+            <a href="{$crossqueryPath}?{$moreString};startDoc={$startDoc};rmode=showDescrip#{$identifier}">[more]</a>  
          </xsl:when>
          <xsl:otherwise>
             <xsl:apply-templates/>
@@ -661,7 +661,7 @@
    <xsl:template name="rawDisplay.url">
       <xsl:param name="path"/>
       <xsl:variable name="file" select="replace($path, '[^:]+:(.*)', '$1')"/>
-      <xsl:value-of select="concat($xtfURL, 'data/', $file)"/>
+      <xsl:value-of select="concat('data/', $file)"/>
    </xsl:template>
    
    <!-- ====================================================================== -->
@@ -811,7 +811,7 @@
             <span style="color: red"><xsl:value-of select="upper-case($alpha)"/></span>
          </xsl:when>
           <xsl:when test="/crossQueryResult/facet[@field=concat('browse-',$browse-name)]/group[@value=$browse-link]">
-            <a href="{$xtfURL}{$crossqueryPath}?browse-{$browse-name}={$browse-link};sort={$browse-name}"><xsl:value-of select="$alpha"/></a>
+            <a href="{$crossqueryPath}?browse-{$browse-name}={$browse-link};sort={$browse-name}"><xsl:value-of select="$alpha"/></a>
          </xsl:when>
          <xsl:otherwise>
             <xsl:value-of select="upper-case($alpha)"/>
@@ -871,7 +871,7 @@
                   <xsl:variable name="NS" select="($NP * 90) + 1"/>
                   
                   <xsl:if test="($NS &lt; $TD) and ($NP &lt; $PM)">
-                     <a href="{$xtfURL}search?startDoc={$NS}"><xsl:value-of select="$NP"/></a>
+                     <a href="search?startDoc={$NS}"><xsl:value-of select="$NP"/></a>
                      <br/>
                   </xsl:if>
                   
@@ -921,7 +921,7 @@
          </div>
          <xsl:if test="$expand=$field">
             <div class="facetLess">
-               <i><a href="{$xtfURL}{$crossqueryPath}?{editURL:remove($queryString,'expand')}">less</a></i>
+               <i><a href="{$crossqueryPath}?{editURL:remove($queryString,'expand')}">less</a></i>
             </div>
          </xsl:if>
          <div class="facetGroup">
@@ -931,7 +931,7 @@
          </div>
          <xsl:if test="$needExpand and not($expand=$field)">
             <div class="facetMore">
-               <i><a href="{$xtfURL}{$crossqueryPath}?{editURL:set($queryString,'expand',$field)}">more</a></i>
+               <i><a href="{$crossqueryPath}?{editURL:set($queryString,'expand',$field)}">more</a></i>
             </div>
          </xsl:if>
       </div>

--- a/style/crossQuery/resultFormatter/default/resultFormatter.xsl
+++ b/style/crossQuery/resultFormatter/default/resultFormatter.xsl
@@ -67,8 +67,8 @@
    <!-- Local Parameters                                                       -->
    <!-- ====================================================================== -->
    
-   <xsl:param name="css.path" select="concat($xtfURL, 'css/default/')"/>
-   <xsl:param name="icon.path" select="concat($xtfURL, 'icons/default/')"/>
+   <xsl:param name="css.path" select=" 'css/default/' "/>
+   <xsl:param name="icon.path" select=" 'icons/default/' "/>
    <xsl:param name="docHits" select="/crossQueryResult/docHit"/>
    <xsl:param name="email"/>
    
@@ -172,8 +172,8 @@
             <xsl:copy-of select="$brand.links"/>
             <!-- AJAX support -->
             <script src="//code.jquery.com/jquery-latest.min.js" type="text/javascript"/>
-            <script src="{$xtfURL}script/bookbag.js" type="text/javascript"/>
-            <script src="{$xtfURL}script/moreLike.js" type="text/javascript"/>
+            <script src="script/bookbag.js" type="text/javascript"/>
+            <script src="script/moreLike.js" type="text/javascript"/>
          </head>
          <body>
             
@@ -187,7 +187,7 @@
                      <td colspan="2" class="right">
                         <xsl:if test="$smode != 'showBag'">
                            <xsl:variable name="bag" select="session:getData('bag')"/>
-                           <a href="{$xtfURL}{$crossqueryPath}?smode=showBag">Bookbag</a>
+                           <a href="{$crossqueryPath}?smode=showBag">Bookbag</a>
                            (<span id="bagCount"><xsl:value-of select="count($bag/bag/savedDoc)"/></span>)
                         </xsl:if>
                      </td>
@@ -199,8 +199,7 @@
                               <a>
                                  <xsl:attribute name="href">javascript://</xsl:attribute>
                                  <xsl:attribute name="onclick">
-                                    <xsl:text>javascript:window.open('</xsl:text><xsl:value-of
-                                       select="$xtfURL"/>search?smode=getAddress<xsl:text>','popup','width=500,height=200,resizable=no,scrollbars=no')</xsl:text>
+                                    <xsl:text>javascript:window.open('search?smode=getAddress','popup','width=500,height=200,resizable=no,scrollbars=no')</xsl:text>
                                  </xsl:attribute>
                                  <xsl:text>E-mail My Bookbag</xsl:text>
                               </a>
@@ -224,12 +223,12 @@
                            <xsl:text>&#160;|&#160;</xsl:text>
                         </xsl:if>
                         <xsl:if test="$smode != 'showBag'">
-                           <a href="{$xtfURL}{$crossqueryPath}?{$modifyString}">
+                           <a href="{$crossqueryPath}?{$modifyString}">
                               <xsl:text>Modify Search</xsl:text>
                            </a>
                            <xsl:text>&#160;|&#160;</xsl:text>
                         </xsl:if>
-                        <a href="{$xtfURL}{$crossqueryPath}">
+                        <a href="{$crossqueryPath}">
                            <xsl:text>New Search</xsl:text>
                         </a>
                         <xsl:if test="$smode = 'showBag'">
@@ -244,7 +243,7 @@
                      <tr>
                         <td>
                            <xsl:call-template name="did-you-mean">
-                              <xsl:with-param name="baseURL" select="concat($xtfURL, $crossqueryPath, '?', $queryString)"/>
+                              <xsl:with-param name="baseURL" select="concat($crossqueryPath, '?', $queryString)"/>
                               <xsl:with-param name="spelling" select="//spelling"/>
                            </xsl:call-template>
                         </td>
@@ -276,7 +275,7 @@
                   <xsl:if test="docHit">
                      <tr>
                         <td>
-                           <form method="get" action="{$xtfURL}{$crossqueryPath}">
+                           <form method="get" action="{$crossqueryPath}">
                               <b>Sorted by:&#160;</b>
                               <xsl:call-template name="sort.options"/>
                               <xsl:call-template name="hidden.query">
@@ -373,7 +372,7 @@
             <xsl:copy-of select="$brand.header"/>
             <div class="getAddress">
                <h2>E-mail My Bookbag</h2>
-               <form action="{$xtfURL}{$crossqueryPath}" method="get">
+               <form action="{$crossqueryPath}" method="get">
                   <xsl:text>Address: </xsl:text>
                   <input type="text" name="email"/>
                   <xsl:text>&#160;</xsl:text>
@@ -424,7 +423,6 @@ Your XTF Bookbag:
       <xsl:for-each select="$docHits[string(meta/identifier[1]) = $id][1]">
          <xsl:variable name="path" select="@path"/>
          <xsl:variable name="url">
-            <xsl:value-of select="$xtfURL"/>
             <xsl:choose>
                <xsl:when test="matches(meta/display, 'dynaxml')">
                   <xsl:call-template name="dynaxml.url">
@@ -460,8 +458,8 @@ Item number <xsl:value-of select="$num"/>:
             <xsl:copy-of select="$brand.links"/>
             <!-- AJAX support -->
             <script src="//code.jquery.com/jquery-latest.min.js" type="text/javascript"/>
-            <script src="{$xtfURL}script/bookbag.js" type="text/javascript"/>
-            <script src="{$xtfURL}script/moreLike.js" type="text/javascript"/>
+            <script src="script/bookbag.js" type="text/javascript"/>
+            <script src="script/moreLike.js" type="text/javascript"/>
          </head>
          <body>
             
@@ -474,7 +472,7 @@ Item number <xsl:value-of select="$num"/>:
                   <tr>
                      <td colspan="2" class="right">
                         <xsl:variable name="bag" select="session:getData('bag')"/>
-                        <a href="{$xtfURL}{$crossqueryPath}?smode=showBag">Bookbag</a>
+                        <a href="{$crossqueryPath}?smode=showBag">Bookbag</a>
                         (<span id="bagCount"><xsl:value-of select="count($bag/bag/savedDoc)"/></span>)
                      </td>
                   </tr>
@@ -488,7 +486,7 @@ Item number <xsl:value-of select="$num"/>:
                         </xsl:choose>
                      </td>
                      <td class="right">
-                        <a href="{$xtfURL}{$crossqueryPath}">
+                        <a href="{$crossqueryPath}">
                            <xsl:text>New Search</xsl:text>
                         </a>
                         <xsl:if test="$smode = 'showBag'">
@@ -559,27 +557,27 @@ Item number <xsl:value-of select="$num"/>:
       <xsl:choose>
          <xsl:when test="$browse-all">
             <xsl:text>Facet | </xsl:text>
-            <a href="{$xtfURL}{$crossqueryPath}?browse-title=first;sort=title">Title</a>
+            <a href="{$crossqueryPath}?browse-title=first;sort=title">Title</a>
             <xsl:text> | </xsl:text>
-            <a href="{$xtfURL}{$crossqueryPath}?browse-creator=first;sort=creator">Author</a>
+            <a href="{$crossqueryPath}?browse-creator=first;sort=creator">Author</a>
          </xsl:when>
          <xsl:when test="$browse-title">
-            <a href="{$xtfURL}{$crossqueryPath}?browse-all=yes">Facet</a>
+            <a href="{$crossqueryPath}?browse-all=yes">Facet</a>
             <xsl:text> | Title | </xsl:text>
-            <a href="{$xtfURL}{$crossqueryPath}?browse-creator=first;sort=creator">Author</a>
+            <a href="{$crossqueryPath}?browse-creator=first;sort=creator">Author</a>
          </xsl:when>
          <xsl:when test="$browse-creator">
-            <a href="{$xtfURL}{$crossqueryPath}?browse-all=yes">Facet</a>
+            <a href="{$crossqueryPath}?browse-all=yes">Facet</a>
             <xsl:text> | </xsl:text>
-            <a href="{$xtfURL}{$crossqueryPath}?browse-title=first;sort=title">Title</a>
+            <a href="{$crossqueryPath}?browse-title=first;sort=title">Title</a>
             <xsl:text>  | Author</xsl:text>
          </xsl:when>
          <xsl:otherwise>
-            <a href="{$xtfURL}{$crossqueryPath}?browse-all=yes">Facet</a>
+            <a href="{$crossqueryPath}?browse-all=yes">Facet</a>
             <xsl:text> | </xsl:text>
-            <a href="{$xtfURL}{$crossqueryPath}?browse-title=first;sort=title">Title</a>
+            <a href="{$crossqueryPath}?browse-title=first;sort=title">Title</a>
             <xsl:text> | </xsl:text>
-            <a href="{$xtfURL}{$crossqueryPath}?browse-creator=first;sort=creator">Author</a>
+            <a href="{$crossqueryPath}?browse-creator=first;sort=creator">Author</a>
          </xsl:otherwise>
       </xsl:choose>
    </xsl:template>

--- a/style/crossQuery/resultFormatter/default/rss.xsl
+++ b/style/crossQuery/resultFormatter/default/rss.xsl
@@ -19,8 +19,7 @@
                     <!-- For these reasons, a feed should contain an atom:link used for this purpose. -->
                     <atom:link rel="self" type="application/rss+xml">
                         <xsl:attribute name="href">
-                            <xsl:value-of select="concat($xtfURL,'search?')"/>
-                            <xsl:value-of select="replace(replace($queryString,' ','%20'),'&quot;','%22')"/>
+                            <xsl:value-of select="concat('search?', replace(replace($queryString,' ','%20'),'&quot;','%22'))"/>
                         </xsl:attribute>
                     </atom:link>
 
@@ -41,7 +40,7 @@
 
                     <!-- RSS 2.0: The URL to the HTML website corresponding to the channel. -->
                     <link>
-                        <xsl:value-of select="concat($xtfURL,'search?')"/>
+                        <xsl:text>search?</xsl:text>
                         <xsl:value-of select="replace(xtf:urlEncode(replace($queryString,';entity-ignore=[A-Za-z0-9_\-]*|;docsPerPage=\d*|;rmode=[A-Za-z0-9_\-]*|;sort=[A-Za-z0-9_\-]*','')),'&quot;','%22')"/>
                     </link>
 
@@ -77,7 +76,6 @@
         <xsl:variable name="href">
             <xsl:choose>
                 <xsl:when test="matches(meta/display, 'dynaxml')">
-                    <xsl:value-of select="$xtfURL"/>
                     <xsl:call-template name="dynaxml.url">
                         <xsl:with-param name="path" select="$path"/>
                     </xsl:call-template>

--- a/style/crossQuery/resultFormatter/default/searchForms.xsl
+++ b/style/crossQuery/resultFormatter/default/searchForms.xsl
@@ -109,14 +109,14 @@
    
    <!-- simple form -->
    <xsl:template name="simpleForm" exclude-result-prefixes="#all">
-      <form method="get" action="{$xtfURL}{$crossqueryPath}">
+      <form method="get" action="{$crossqueryPath}">
          <table>
             <tr>
                <td>
                   <input type="text" name="keyword" size="40" value="{$keyword}"/>
                   <xsl:text>&#160;</xsl:text>
                   <input type="submit" value="Search"/>
-                  <input type="reset" onclick="location.href='{$xtfURL}{$crossqueryPath}'" value="Clear"/>
+                  <input type="reset" onclick="location.href='{$crossqueryPath}'" value="Clear"/>
                </td>
             </tr>
             <tr>
@@ -154,7 +154,7 @@
    
    <!-- advanced form -->
    <xsl:template name="advancedForm" exclude-result-prefixes="#all">
-      <form method="get" action="{$xtfURL}{$crossqueryPath}">
+      <form method="get" action="{$crossqueryPath}">
          <table class="top_table">
             <tr>
                <td>
@@ -374,7 +374,7 @@
                         <td>
                            <input type="hidden" name="smode" value="advanced"/>
                            <input type="submit" value="Search"/>
-                           <input type="reset" onclick="location.href='{$xtfURL}{$crossqueryPath}?smode=advanced'" value="Clear"/>
+                           <input type="reset" onclick="location.href='{$crossqueryPath}?smode=advanced'" value="Clear"/>
                         </td>
                      </tr>
                   </table>
@@ -425,7 +425,7 @@
    
    <!-- free-form form -->
    <xsl:template name="freeformForm" exclude-result-prefixes="#all">
-      <form method="get" action="{$xtfURL}{$crossqueryPath}">
+      <form method="get" action="{$crossqueryPath}">
          <table>
             <tr>
                <td>
@@ -433,7 +433,7 @@
                   <input type="text" name="freeformQuery" size="40" value="{$freeformQuery}"/>
                   <xsl:text>&#160;</xsl:text>
                   <input type="submit" value="Search"/>
-                  <input type="reset" onclick="location.href='{$xtfURL}{$crossqueryPath}'" value="Clear"/>
+                  <input type="reset" onclick="location.href='{$crossqueryPath}'" value="Clear"/>
                </td>
             </tr>
             <tr>

--- a/style/crossQuery/resultFormatter/siteMap/resultFormatter.xsl
+++ b/style/crossQuery/resultFormatter/siteMap/resultFormatter.xsl
@@ -16,7 +16,7 @@
    <!-- ====================================================================== -->
    
    <xsl:import href="../common/resultFormatterCommon.xsl"/>
-   <xsl:param name="icon.path" select="concat($xtfURL, 'icons/default/')"/>
+   <xsl:param name="icon.path" select=" 'icons/default/' "/>
    
    <!-- ====================================================================== -->
    <!-- Output                                                                 -->
@@ -40,7 +40,7 @@
 
       <xsl:variable name="identifier" select="meta/identifier"/>
       <xsl:variable name="id" select="replace(@path,'^default:','')"/>
-      <xsl:variable name="loc" select="concat($xtfURL,'view?docId=',$id)"/>
+      <xsl:variable name="loc" select="concat('view?docId=',$id)"/>
 
       <url xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
          <loc xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">

--- a/style/dynaXML/docFormatter/bookreader/bookDocFormatter.xsl
+++ b/style/dynaXML/docFormatter/bookreader/bookDocFormatter.xsl
@@ -148,7 +148,7 @@
                   </tr>
                   <tr>
                      <td class="left">
-                        <a href="{$xtfURL}search" target="_top">Home</a><xsl:text> | </xsl:text>
+                        <a href="search" target="_top">Home</a><xsl:text> | </xsl:text>
                         <xsl:choose>
                            <xsl:when test="session:getData('queryURL')">
                               <a href="{session:getData('queryURL')}" target="_top">Return to Search Results</a>
@@ -159,7 +159,7 @@
                         </xsl:choose>
                      </td>
                      <td width="34%" class="center">
-                        <form action="{$xtfURL}{$dynaxmlPath}" target="_top" method="get">
+                        <form action="{$dynaxmlPath}" target="_top" method="get">
                            <input name="query" type="text" size="15"/>
                            <input type="hidden" name="docId" value="{$docId}"/>
                            <input type="hidden" name="hit.rank" value="1"/>

--- a/style/dynaXML/docFormatter/common/docFormatterCommon.xsl
+++ b/style/dynaXML/docFormatter/common/docFormatterCommon.xsl
@@ -77,7 +77,7 @@
    
    <xsl:param name="query.string" select="concat('docId=', $docId, $sourceStr)"/>
    
-   <xsl:param name="doc.path"><xsl:value-of select="$xtfURL"/><xsl:value-of select="$dynaxmlPath"/>?<xsl:value-of select="$query.string"/></xsl:param>
+   <xsl:param name="doc.path"><xsl:value-of select="$dynaxmlPath"/>?<xsl:value-of select="$query.string"/></xsl:param>
    
    <xsl:variable name="systemId" select="saxon:systemId()" xmlns:saxon="http://saxon.sf.net/"/>
    
@@ -87,7 +87,7 @@
             <xsl:value-of select="replace($systemId, '/[^/]*$', '')"/>
          </xsl:when>
          <xsl:otherwise>
-            <xsl:value-of select="concat($xtfURL, 'data/', $docPath)"/>
+            <xsl:value-of select="concat('data/', $docPath)"/>
          </xsl:otherwise>
       </xsl:choose>
    </xsl:param>
@@ -186,7 +186,7 @@
                         </tr>
                         <tr>
                            <td class="left">
-                              <a href="{$xtfURL}search" target="_top">Home</a><xsl:text> | </xsl:text>
+                              <a href="search" target="_top">Home</a><xsl:text> | </xsl:text>
                               <xsl:choose>
                                  <xsl:when test="session:getData('queryURL')">
                                     <a href="{session:getData('queryURL')}" target="_top">Return to Search Results</a>
@@ -197,7 +197,7 @@
                               </xsl:choose>
                            </td>
                            <td width="34%" class="center">
-                              <form action="{$xtfURL}{$dynaxmlPath}" target="_top" method="get">
+                              <form action="{$dynaxmlPath}" target="_top" method="get">
                                  <input name="query" type="text" size="15"/>
                                  <input type="hidden" name="docId" value="{$docId}"/>
                                  <input type="hidden" name="chunk.id" value="{$chunk.id}"/>
@@ -208,7 +208,7 @@
                               <a>
                                  <xsl:attribute name="href">javascript://</xsl:attribute>
                                  <xsl:attribute name="onclick">
-                                    <xsl:text>javascript:window.open('</xsl:text><xsl:value-of select="$xtfURL"/><xsl:value-of select="$dynaxmlPath"/><xsl:text>?docId=</xsl:text><xsl:value-of
+                                    <xsl:text>javascript:window.open('</xsl:text><xsl:value-of select="$dynaxmlPath"/><xsl:text>?docId=</xsl:text><xsl:value-of
                                        select="$docId"/><xsl:text>;doc.view=citation</xsl:text><xsl:text>','popup','width=800,height=400,resizable=yes,scrollbars=no')</xsl:text>
                                  </xsl:attribute>
                                  <xsl:text>Citation</xsl:text>
@@ -250,7 +250,7 @@
                   <p><xsl:value-of select="/*/*:meta/*:creator[1]"/>. 
                      <xsl:value-of select="/*/*:meta/*:title[1]"/>. 
                      <xsl:value-of select="/*/*:meta/*:year[1]"/>.<br/>
-                     [<xsl:value-of select="concat($xtfURL,$dynaxmlPath,'?docId=',$docId)"/>]</p>
+                     [<xsl:value-of select="concat($dynaxmlPath,'?docId=',$docId)"/>]</p>
                   <a>
                      <xsl:attribute name="href">javascript://</xsl:attribute>
                      <xsl:attribute name="onClick">

--- a/style/dynaXML/docFormatter/ead/eadDocFormatter.xsl
+++ b/style/dynaXML/docFormatter/ead/eadDocFormatter.xsl
@@ -189,16 +189,16 @@
             <frameset rows="120,*">
                <frame frameborder="1" scrolling="no" title="Navigation Bar">
                   <xsl:attribute name="name">bbar</xsl:attribute>
-                  <xsl:attribute name="src"><xsl:value-of select="$xtfURL"/><xsl:value-of select="$dynaxmlPath"/>?<xsl:value-of select="$bbar.href"/></xsl:attribute>
+                  <xsl:attribute name="src"><xsl:value-of select="$dynaxmlPath"/>?<xsl:value-of select="$bbar.href"/></xsl:attribute>
                </frame>
                <frameset cols="35%,65%">
                   <frame frameborder="1" title="Table of Contents">
                      <xsl:attribute name="name">toc</xsl:attribute>
-                     <xsl:attribute name="src"><xsl:value-of select="$xtfURL"/><xsl:value-of select="$dynaxmlPath"/>?<xsl:value-of select="$toc.href"/></xsl:attribute>
+                     <xsl:attribute name="src"><xsl:value-of select="$dynaxmlPath"/>?<xsl:value-of select="$toc.href"/></xsl:attribute>
                   </frame>
                   <frame frameborder="1" title="Content">
                      <xsl:attribute name="name">content</xsl:attribute>
-                     <xsl:attribute name="src"><xsl:value-of select="$xtfURL"/><xsl:value-of select="$dynaxmlPath"/>?<xsl:value-of select="$content.href"/>#X</xsl:attribute>
+                     <xsl:attribute name="src"><xsl:value-of select="$dynaxmlPath"/>?<xsl:value-of select="$content.href"/>#X</xsl:attribute>
                   </frame>
                </frameset>
                <noframes>
@@ -484,7 +484,7 @@
                      <xsl:otherwise>
                         <a>
                            <xsl:attribute name="href">
-                              <xsl:value-of select="$xtfURL"/><xsl:value-of select="$dynaxmlPath"/>?<xsl:value-of select="$content.href"/>
+                              <xsl:value-of select="$dynaxmlPath"/>?<xsl:value-of select="$content.href"/>
                            </xsl:attribute>
                            <xsl:attribute name="target">_top</xsl:attribute>
                            <xsl:value-of select="$name"/>

--- a/style/dynaXML/docFormatter/ead/parameter.xsl
+++ b/style/dynaXML/docFormatter/ead/parameter.xsl
@@ -33,9 +33,9 @@
       POSSIBILITY OF SUCH DAMAGE.
    -->
    
-   <xsl:param name="icon.path" select="concat($xtfURL, 'icons/default/')"/>
+   <xsl:param name="icon.path" select=" 'icons/default/' "/>
    
-   <xsl:param name="css.path" select="concat($xtfURL, 'css/default/')"/>
+   <xsl:param name="css.path" select=" 'css/default/' "/>
    
    <xsl:variable name="doc.title" select="string(/ead/xtf:meta/title)"/>
    

--- a/style/dynaXML/docFormatter/ead/search.xsl
+++ b/style/dynaXML/docFormatter/ead/search.xsl
@@ -143,7 +143,7 @@
                <xsl:otherwise>
                   <xsl:attribute name="target" select="'_top'"/>
                   <xsl:attribute name="href" select="
-                     concat($xtfURL, $dynaxmlPath, '?', $query.string, 
+                     concat($dynaxmlPath, '?', $query.string, 
                             ';hit.num=', $prev, ';brand=', $brand, $search)"/>
                </xsl:otherwise>
             </xsl:choose>
@@ -177,7 +177,7 @@
                <xsl:otherwise>
                   <xsl:attribute name="target" select="'_top'"/>
                   <xsl:attribute name="href" select="
-                     concat($xtfURL, $dynaxmlPath, '?', $query.string, 
+                     concat($dynaxmlPath, '?', $query.string, 
                             ';hit.num=', $next, ';brand=', $brand, $search)"/>
                </xsl:otherwise>
             </xsl:choose>

--- a/style/dynaXML/docFormatter/nlm/ViewNLM-v2.3.xsl
+++ b/style/dynaXML/docFormatter/nlm/ViewNLM-v2.3.xsl
@@ -605,7 +605,7 @@
 	<xsl:template name="make-src">
 		<xsl:if test="@xlink:href">
 			<xsl:attribute name="src">
-				<xsl:value-of select="concat($xtfURL,'data/',$ID,'figures/',@xlink:href)"/>
+				<xsl:value-of select="concat('data/',$ID,'figures/',@xlink:href)"/>
 			</xsl:attribute>
 		</xsl:if>
 	</xsl:template>

--- a/style/dynaXML/docFormatter/nlm/nlmDocFormatter.xsl
+++ b/style/dynaXML/docFormatter/nlm/nlmDocFormatter.xsl
@@ -93,7 +93,7 @@
    <!-- ====================================================================== -->
    
    <xsl:param name="ID" select="replace($docId,'[A-Za-z0-9]+\.xml$','')"/>
-   <xsl:param name="icon.path" select="concat($xtfURL, 'icons/default/')"/>
+   <xsl:param name="icon.path" select=" 'icons/default/' "/>
    <xsl:param name="doc.title" select="/article/front/article-meta/title-group/article-title[1]"/>
    <xsl:param name="css.path" select="'css/default/'"/>
    <xsl:param name="content.css" select="'nlm.css'"/>
@@ -150,16 +150,16 @@
             <frameset rows="120,*">
                <frame frameborder="1" scrolling="no" title="Navigation Bar">
                   <xsl:attribute name="name">bbar</xsl:attribute>
-                  <xsl:attribute name="src"><xsl:value-of select="$xtfURL"/>view?<xsl:value-of select="$bbar.href"/></xsl:attribute>
+                  <xsl:attribute name="src">view?<xsl:value-of select="$bbar.href"/></xsl:attribute>
                </frame>
                <frameset cols="25%,75%">
                   <frame frameborder="1" title="Table of Contents">
                      <xsl:attribute name="name">toc</xsl:attribute>
-                     <xsl:attribute name="src"><xsl:value-of select="$xtfURL"/>view?<xsl:value-of select="$toc.href"/></xsl:attribute>
+                     <xsl:attribute name="src">view?<xsl:value-of select="$toc.href"/></xsl:attribute>
                   </frame>
                   <frame frameborder="1" title="Content">
                      <xsl:attribute name="name">content</xsl:attribute>
-                     <xsl:attribute name="src"><xsl:value-of select="$xtfURL"/>view?<xsl:value-of select="$content.href"/></xsl:attribute>
+                     <xsl:attribute name="src">view?<xsl:value-of select="$content.href"/></xsl:attribute>
                   </frame>
                </frameset>
                <noframes>
@@ -256,7 +256,7 @@
                </xsl:choose>
             </td>
             <td>
-               <a href="{$xtfURL}{$dynaxmlPath}?docId={$docId};query={$query};brand={$brand};anchor.id={@id}" target="_top">
+               <a href="{$dynaxmlPath}?docId={$docId};query={$query};brand={$brand};anchor.id={@id}" target="_top">
                   <xsl:value-of select="title"/>
                </a>
             </td>

--- a/style/dynaXML/docFormatter/tei/component.xsl
+++ b/style/dynaXML/docFormatter/tei/component.xsl
@@ -594,7 +594,14 @@
    <!-- ====================================================================== -->
    <!-- References                                                             -->
    <!-- ====================================================================== -->
-   
+   <!-- links to absolute HTTP(s) URIs -->
+   <xsl:template match="*:ref[matches(@target, '^https?://')]">
+      <xsl:element name="a">
+         <xsl:attribute name="href" select="@target"/>
+         <xsl:apply-templates/>
+      </xsl:element>
+   </xsl:template>
+ 
    <xsl:template match="*:ref">
       
       <!-- variables -->

--- a/style/dynaXML/docFormatter/tei/parameter.xsl
+++ b/style/dynaXML/docFormatter/tei/parameter.xsl
@@ -33,9 +33,9 @@
       POSSIBILITY OF SUCH DAMAGE.
    -->
       
-   <xsl:param name="icon.path" select="concat($xtfURL, 'icons/default/')"/>
+   <xsl:param name="icon.path" select=" 'icons/default/' "/>
    
-   <xsl:param name="css.path" select="concat($xtfURL, 'css/default/')"/>
+   <xsl:param name="css.path" select=" 'css/default/' "/>
    
    <xsl:param name="content.css" select="'tei.css'"/>
    

--- a/style/dynaXML/docFormatter/tei/teiDocFormatter.xsl
+++ b/style/dynaXML/docFormatter/tei/teiDocFormatter.xsl
@@ -189,16 +189,16 @@
             <frameset rows="120,*">
                <frame frameborder="1" scrolling="no" title="Navigation Bar">
                   <xsl:attribute name="name">bbar</xsl:attribute>
-                  <xsl:attribute name="src"><xsl:value-of select="$xtfURL"/>view?<xsl:value-of select="$bbar.href"/></xsl:attribute>
+                  <xsl:attribute name="src">view?<xsl:value-of select="$bbar.href"/></xsl:attribute>
                </frame>
                <frameset cols="35%,65%">
                   <frame frameborder="1" title="Table of Contents">
                      <xsl:attribute name="name">toc</xsl:attribute>
-                     <xsl:attribute name="src"><xsl:value-of select="$xtfURL"/>view?<xsl:value-of select="$toc.href"/></xsl:attribute>
+                     <xsl:attribute name="src">view?<xsl:value-of select="$toc.href"/></xsl:attribute>
                   </frame>
                   <frame frameborder="1" title="Content">
                      <xsl:attribute name="name">content</xsl:attribute>
-                     <xsl:attribute name="src"><xsl:value-of select="$xtfURL"/>view?<xsl:value-of select="$content.href"/></xsl:attribute>
+                     <xsl:attribute name="src">view?<xsl:value-of select="$content.href"/></xsl:attribute>
                   </frame>
                </frameset>
                <noframes>

--- a/style/textIndexer/docSelector.xsl
+++ b/style/textIndexer/docSelector.xsl
@@ -153,8 +153,8 @@
                                         matches($uri,'ead\.dtd') or 
                                         matches($ns,'ead')">
                            <indexFile fileName="{$fileName}"
-                              preFilter="style/textIndexer/ead/eadPreFilter.xsl"
-                              displayStyle="style/dynaXML/docFormatter/ead/eadDocFormatter.xsl"/>
+                              preFilter="local/style/textIndexer/ead/eadPreFilter.xsl"
+                              displayStyle="local/style/dynaXML/docFormatter/ead/eadDocFormatter.xsl"/>
                         </xsl:when>
                         <!-- Look for NLM XML files -->
                         <xsl:when test="matches($root-element-name,'^article$') or
@@ -162,8 +162,8 @@
                                         matches($uri,'journalpublishing\.dtd') or 
                                         matches($ns,'nlm')">
                            <indexFile fileName="{$fileName}"
-                              preFilter="style/textIndexer/nlm/nlmPreFilter.xsl"
-                              displayStyle="style/dynaXML/docFormatter/nlm/nlmDocFormatter.xsl"/>
+                              preFilter="local/style/textIndexer/nlm/nlmPreFilter.xsl"
+                              displayStyle="local/style/dynaXML/docFormatter/nlm/nlmDocFormatter.xsl"/>
                         </xsl:when>
                         <!-- Look for TEI XML file -->
                         <xsl:when test="matches($root-element-name,'^TEI') or 
@@ -171,8 +171,8 @@
                            matches($uri,'tei2\.dtd') or 
                            matches($ns,'tei')">
                            <indexFile fileName="{$fileName}"
-                              preFilter="style/textIndexer/tei/teiPreFilter.xsl"
-                              displayStyle="style/dynaXML/docFormatter/tei/teiDocFormatter.xsl"/>
+                              preFilter="local/style/textIndexer/tei/teiPreFilter.xsl"
+                              displayStyle="local/style/dynaXML/docFormatter/tei/teiDocFormatter.xsl"/>
                         </xsl:when>
                         <!-- DjVu files are typically subordinate to a main doc -->
                         <xsl:when test="matches($root-element-name, 'DjVuXML')">
@@ -183,15 +183,15 @@
                            <xsl:variable name="metsData" select="document($file)"/>
                            <xsl:if test="$metsData//*:book">
                               <indexFile fileName="{$fileName}"
-                                 preFilter="style/textIndexer/bookreader/bookPreFilter.xsl"
-                                 displayStyle="style/dynaXML/docFormatter/bookreader/bookDocFormatter.xsl"/>
+                                 preFilter="local/style/textIndexer/bookreader/bookPreFilter.xsl"
+                                 displayStyle="local/style/dynaXML/docFormatter/bookreader/bookDocFormatter.xsl"/>
                            </xsl:if>
                         </xsl:when>
                         <!-- Default processing for XML files -->
                         <xsl:otherwise>
                            <indexFile fileName="{$fileName}" 
                               type="XML"
-                              preFilter="style/textIndexer/default/defaultPreFilter.xsl"/>
+                              preFilter="local/style/textIndexer/default/defaultPreFilter.xsl"/>
                            <xsl:message select="'Unrecognized XML structure. Indexing using the default preFilter.'"/>
                         </xsl:otherwise>
                      </xsl:choose>
@@ -204,35 +204,35 @@
          <xsl:when test="ends-with(@fileName, 'html') or ends-with(@fileName, '.xhtml')">
             <indexFile fileName="{@fileName}" 
                type="HTML"
-               preFilter="style/textIndexer/html/htmlPreFilter.xsl"/>
+               preFilter="local/style/textIndexer/html/htmlPreFilter.xsl"/>
          </xsl:when>
          
          <!-- PDF files -->
          <xsl:when test="ends-with(@fileName, '.pdf')">
             <indexFile fileName="{@fileName}" 
                type="PDF"
-               preFilter="style/textIndexer/default/defaultPreFilter.xsl"/>
+               preFilter="local/style/textIndexer/default/defaultPreFilter.xsl"/>
          </xsl:when>
          
          <!-- Microsoft Word documents -->
          <xsl:when test="ends-with(@fileName, '.doc')">
             <indexFile fileName="{@fileName}" 
                type="MSWord"
-               preFilter="style/textIndexer/default/defaultPreFilter.xsl"/>
+               preFilter="local/style/textIndexer/default/defaultPreFilter.xsl"/>
          </xsl:when>
          
          <!-- Plain text files. Exception: skip book/*.txt as they're typically subordinate. -->
          <xsl:when test="ends-with(@fileName, '.txt') and not(matches($dirPath, '/bookreader/'))">
             <indexFile fileName="{@fileName}" 
                type="text"
-               preFilter="style/textIndexer/default/defaultPreFilter.xsl"/>
+               preFilter="local/style/textIndexer/default/defaultPreFilter.xsl"/>
          </xsl:when>
 
          <!-- MARC files -->
          <xsl:when test="ends-with(@fileName, '.mrc')">
             <indexFile fileName="{@fileName}" 
                type="MARC"
-               preFilter="style/textIndexer/default/defaultPreFilter.xsl"/>
+               preFilter="local/style/textIndexer/default/defaultPreFilter.xsl"/>
          </xsl:when>
       </xsl:choose>
       

--- a/style/textIndexer/tei/teiPreFilter.xsl
+++ b/style/textIndexer/tei/teiPreFilter.xsl
@@ -248,7 +248,7 @@
             </publisher>
          </xsl:when>
          <xsl:when test="//*:text/*:front/*:titlePage//*:publisher">
-            <publisher xtf-meta="true">
+            <publisher xtf:meta="true">
                <xsl:value-of select="string(//*:text/*:front/*:titlePage//*:publisher[1])"/>
             </publisher>
          </xsl:when>
@@ -264,7 +264,7 @@
    <xsl:template name="get-tei-contributor">
       <xsl:choose>
          <xsl:when test="//*:fileDesc/*:respStmt/*:name">
-            <contributor xtf-meta="true">
+            <contributor xtf:meta="true">
                <xsl:value-of select="string(//*:fileDesc/*:respStmt/*:name[1])"/>
             </contributor>
          </xsl:when>
@@ -327,7 +327,7 @@
    <xsl:template name="get-tei-source">
       <xsl:choose>
          <xsl:when test="//*:sourceDesc/*:bibl">
-            <source xtf-meta="true">
+            <source xtf:meta="true">
                <xsl:value-of select="string(//*:sourceDesc/*:bibl[1])"/>
             </source>
          </xsl:when>
@@ -343,7 +343,7 @@
    <xsl:template name="get-tei-language">
       <xsl:choose>
          <xsl:when test="//*:profileDesc/*:langUsage/*:language">
-            <language xtf-meta="true">
+            <language xtf:meta="true">
                <xsl:value-of select="string((//*:profileDesc/*:langUsage/*:language)[1])"/>
             </language>
          </xsl:when>
@@ -359,7 +359,7 @@
    <xsl:template name="get-tei-relation">
       <xsl:choose>
          <xsl:when test="//*:fileDesc/*:seriesStmt/*:title">
-            <relation xtf-meta="true">
+            <relation xtf:meta="true">
                <xsl:value-of select="string(//*:fileDesc/*:seriesStmt/*:title)"/>
             </relation>
          </xsl:when>
@@ -380,7 +380,7 @@
    
    <!-- rights -->
    <xsl:template name="get-tei-rights">
-      <rights xtf-meta="true">
+      <rights xtf:meta="true">
          <xsl:value-of select="'public'"/>
       </rights>
    </xsl:template>


### PR DESCRIPTION
This pull request introduces a "local customisation layer" of XSLT stylesheets to provide a more convenient method of maintaining local changes separate from core functionality. 

Normally, implementers of XTF have directly edited the core stylesheets to customise them, and this has posed a maintenance burden when the original stylesheets are updated by a new version of XTF. Either the local customisations must from time to time be merged with those changes to the core XTF, or else the code-bases will diverge, and users will lag in upgrading XTF. 

In the new mechanism, rather than directly invoking one of the core stylesheets, XTF now invokes the similarly-named `local` stylesheet, and it's that `local` stylesheet which is responsible for delegating to the original core stylesheet. The default versions of these local stylesheets defer everything to their equivalent core stylesheets (and therefore don't affect the behaviour of XTF). But any additional templates, variables, keys, etc, declared in a `local` stylesheet will override the equivalent declaration in the core stylesheet. This allows a customiser to keep these customisation files free from anything except the changes themselves, and also to avoid editing the core stylesheets at all.

This PR contains a few other commits (which have since been accepted into the XTF master branch anyway); ignore those. The commit to look at is 30d8f2115115ea322f5df515502b089c831ef286 ("	added XSLT customisation layer in 'local' folder").